### PR TITLE
Add unit tests for encoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+Testing/
 .dep/
 *.o
 *.hex

--- a/encoders.cpp
+++ b/encoders.cpp
@@ -28,12 +28,12 @@ Encoders::Encoders() {
   m_beltShift = Unknown;
   m_carriage = NoCarriage;
   m_encoderPos = 0x00;
+  _oldState = false;
 }
 
 void Encoders::encA_interrupt() {
   m_hallActive = NoDirection;
 
-  static bool _oldState = false;
   bool _curState = digitalRead(ENC_PIN_A);
 
   if (!_oldState && _curState) {

--- a/encoders.h
+++ b/encoders.h
@@ -48,6 +48,7 @@ private:
 
   void encA_rising();
   void encA_falling();
+  bool _oldState;
 };
 
 #endif // ENCODERS_H_

--- a/settings.h
+++ b/settings.h
@@ -28,14 +28,16 @@ This file is part of AYAB.
 
 //  #define DBG_NOMACHINE  // Turn on to use DBG_BTN as EOL Trigger
 
-#ifdef KH910
+#if !defined(AYAB_QUIET)
+#if defined(KH910)
 #warning USING MACHINETYPE KH910
-#else
-#ifdef KH930
+#elif defined(KH930)
 #warning USING MACHINETYPE KH930
-#else
-#error KH910 or KH930 has the be defined as preprocessor variable!
-#endif
+#endif // machine warnings
+#endif // AYAB_QUIET
+
+#if !defined(KH910) && !defined(KH930)
+#error "KH910 or KH930 has the be defined as preprocessor variable!"
 #endif
 
 // Should be calibrated to each device

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.8.8)
+project(ayab_test)
+
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard to be used for compiling")
+
+message("building all tests")
+
+find_package(Threads REQUIRED)
+
+add_subdirectory(arduino_mock)
+
+# Includes arduino-mock files directly inplace of original Arduino headers.
+include_directories(
+    ${ARDUINO_MOCK_INCLUDE_DIRS}/arduino-mock
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest/googletest/include
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest/googlemock/include
+)
+
+set(TEST_SRCS
+  ./test_all.cpp
+  ./test_encoders.cpp
+)
+
+set(PROGRAM_SRCS
+  ../encoders.cpp
+)
+
+add_executable(${PROJECT_NAME} ${TEST_SRCS} ${PROGRAM_SRCS})
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE KH910)
+
+target_link_libraries(${PROJECT_NAME}
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/gtest/libgtest.a
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/libgmock.a
+    ${ARDUINO_MOCK_LIBS_DIR}/dist/lib/libarduino_mock.a
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_dependencies(${PROJECT_NAME} arduino_mock)
+
+enable_testing()
+add_test(test_all ${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,29 +14,42 @@ include_directories(
     ${ARDUINO_MOCK_INCLUDE_DIRS}/arduino-mock
     ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest/googletest/include
     ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest/googlemock/include
-)
+    )
 
-set(TEST_SRCS
-  ./test_all.cpp
-  ./test_encoders.cpp
-)
+add_executable(${PROJECT_NAME}
+    ${PROJECT_SOURCE_DIR}/./test_all.cpp
 
-set(PROGRAM_SRCS
-  ../encoders.cpp
-)
+    ${PROJECT_SOURCE_DIR}/../encoders.cpp
+    ${PROJECT_SOURCE_DIR}/./test_encoders.cpp
+    )
 
-add_executable(${PROJECT_NAME} ${TEST_SRCS} ${PROGRAM_SRCS})
-
-target_compile_definitions(${PROJECT_NAME} PRIVATE KH910)
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+    AYAB_QUIET
+    KH910
+    )
+target_compile_options(${PROJECT_NAME} PRIVATE
+    -Wall -Wextra -Wpedantic
+    -Werror
+    -fprofile-arcs -ftest-coverage
+    -g -Og
+    )
 
 target_link_libraries(${PROJECT_NAME}
     ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/gtest/libgtest.a
     ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/libgmock.a
     ${ARDUINO_MOCK_LIBS_DIR}/dist/lib/libarduino_mock.a
     ${CMAKE_THREAD_LIBS_INIT}
-)
+    -lgcov
+    )
 
 add_dependencies(${PROJECT_NAME} arduino_mock)
+
+# add_custom_command(TARGET ${PROJECT_NAME}
+#     POST_BUILD
+#     COMMAND gcovr -r . -e test_* -e arduino_mock*
+#     COMMAND gcovr -r . --branches -e test_* -e arduino_mock*
+#     )
 
 enable_testing()
 add_test(test_all ${PROJECT_NAME})

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,12 @@
+# Testing
+These tests use [arduino-mock](https://github.com/bt-trx/arduino-mock) (itself based on gmock) and gtest.
+
+## Setup
+Make sure you have cmake and gcovr installed on your system.
+
+## Running the tests
+The tests can be run by issuing the following command from the project root:
+
+`./test/test.sh`
+
+Coverage information can be found in `test/build/coverage.html`

--- a/test/arduino_mock/CMakeLists.txt
+++ b/test/arduino_mock/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.8)
+project(arduino_mock_builder C CXX)
+include(ExternalProject)
+
+ExternalProject_Add(arduino_mock
+    GIT_REPOSITORY https://github.com/bt-trx/arduino-mock
+    GIT_TAG bt-trx
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/arduino_mock
+    INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
+)
+
+ExternalProject_Get_Property(arduino_mock source_dir)
+set(ARDUINO_MOCK_INCLUDE_DIRS ${source_dir}/include PARENT_SCOPE)
+
+ExternalProject_Get_Property(arduino_mock binary_dir)
+set(ARDUINO_MOCK_LIBS_DIR ${binary_dir} PARENT_SCOPE)

--- a/test/test.sh
+++ b/test/test.sh
@@ -4,7 +4,7 @@ set -e
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$parent_path"
 
-# cmake -B ./build -S .
+cmake -B ./build -S .
 cmake --build ./build
 cd ./build
 GTEST_COLOR=1 ctest --output-on-failure .

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,14 @@
-cmake -V -B ./build -S .
-cmake -V --build ./build
+#!/bin/bash
+set -e
+# change to script directory
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
+
+# cmake -B ./build -S .
+cmake --build ./build
 cd ./build
-GTEST_COLOR=1 ctest -V --output-on-failure .
+GTEST_COLOR=1 ctest --output-on-failure .
+cd ../..
+gcovr -r . -e test_* -e arduino_mock* --html-details ./test/build/coverage.html --html-title ayab-test
+gcovr -r . -e test_* -e arduino_mock*
+gcovr -r . --branches -e test_* -e arduino_mock*

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,4 @@
+cmake -V -B ./build -S .
+cmake -V --build ./build
+cd ./build
+GTEST_COLOR=1 ctest -V --output-on-failure .

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -1,0 +1,11 @@
+/*
+ * test_all.cpp
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char *argv[])
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -1,0 +1,12 @@
+#include "gtest/gtest.h"
+
+#define KH910
+#include "../encoders.h"
+
+TEST(encoders, mock_works) {
+  ArduinoMock* arduinoMock = arduinoMockInstance();
+  auto e = Encoders();
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A));
+  e.encA_interrupt();
+  releaseArduinoMock();
+}

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -1,12 +1,175 @@
 #include "gtest/gtest.h"
 
-#define KH910
 #include "../encoders.h"
 
-TEST(encoders, mock_works) {
-  ArduinoMock* arduinoMock = arduinoMockInstance();
-  auto e = Encoders();
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A));
-  e.encA_interrupt();
-  releaseArduinoMock();
+using ::testing::Return;
+
+class EncodersTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            arduinoMock = arduinoMockInstance();
+            e = Encoders();
+        }
+
+        void TearDown() override {
+            releaseArduinoMock();
+        }
+
+        ArduinoMock* arduinoMock;
+        Encoders e;
+};
+
+TEST_F(EncodersTest, test_encA_rising_not_in_front) {
+    // We should not enter the falling function
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
+    // Create a rising edge
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(false))
+        .WillOnce(Return(true));
+    // We have not entered the rising function yet
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L)).Times(0);
+    e.encA_interrupt();
+    // Enter rising function, direction is right
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+        .WillOnce(Return(true));
+    // Not in front of Left Hall Sensor
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+        .WillOnce(Return(FILTER_L_MIN));
+    e.encA_interrupt();
+    ASSERT_EQ(e.getDirection(), Right);
+    ASSERT_EQ(e.getPosition(), 0x01);
+    ASSERT_EQ(e.getCarriage(), NoCarriage);
+}
+
+TEST_F(EncodersTest, test_encA_rising_in_front) {
+    // We should not enter the falling function
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
+    // Create a rising edge
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(false));
+    // We have not entered the rising function yet
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L)).Times(0);
+
+    e.encA_interrupt();
+
+    // Create a rising edge
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(true));
+    // Enter rising function, direction is right
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+        .WillOnce(Return(true));
+    // In front of Left Hall Sensor
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+        .WillOnce(Return(FILTER_L_MIN - 1));
+    // Beltshift is regular
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C))
+        .WillOnce(Return(true));
+
+    e.encA_interrupt();
+
+    ASSERT_EQ(e.getDirection(), Right);
+    ASSERT_EQ(e.getHallActive(), Left);
+    ASSERT_EQ(e.getPosition(), 28);
+    ASSERT_EQ(e.getCarriage(), L);
+    ASSERT_EQ(e.getBeltshift(), Regular);
+}
+
+TEST_F(EncodersTest, test_encA_falling_not_in_front) {
+    // Create a falling edge
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true));
+    // We have not entered the falling function yet
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
+
+    // Enter rising function, direction is right
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+        .WillOnce(Return(true));
+    // Not in front of Left Hall Sensor
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+        .WillOnce(Return(FILTER_L_MIN));
+    e.encA_interrupt();
+    e.encA_interrupt();
+
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
+        .WillOnce(Return(FILTER_R_MIN));
+
+    e.encA_interrupt();
+}
+
+TEST_F(EncodersTest, test_encA_falling_in_front) {
+    // Create a falling edge
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true));
+    // We have not entered the falling function yet
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
+
+    // Enter rising function, direction is left
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+        .WillOnce(Return(false));
+    // In front of Left Hall Sensor
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+        .WillOnce(Return(FILTER_L_MIN));
+    e.encA_interrupt();
+    e.encA_interrupt();
+
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
+        .WillOnce(Return(FILTER_R_MIN - 1));
+    // Beltshift is shifted
+    EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C))
+        .WillOnce(Return(true));
+
+    e.encA_interrupt();
+
+    ASSERT_EQ(e.getDirection(), Left);
+    ASSERT_EQ(e.getHallActive(), Right);
+    ASSERT_EQ(e.getPosition(), 227);
+    ASSERT_EQ(e.getCarriage(), K);
+    ASSERT_EQ(e.getBeltshift(), Shifted);
+}
+
+
+TEST_F(EncodersTest, test_getPosition) {
+    byte p = e.getPosition();
+    ASSERT_EQ(p, 0x00);
+}
+
+TEST_F(EncodersTest, test_getBeltshift) {
+    Beltshift_t b = e.getBeltshift();
+    ASSERT_EQ(b, Unknown);
+}
+
+TEST_F(EncodersTest, test_getDirection) {
+    Direction_t d = e.getDirection();
+    ASSERT_EQ(d, NoDirection);
+}
+
+TEST_F(EncodersTest, test_getHallActive) {
+    Direction_t d = e.getHallActive();
+    ASSERT_EQ(d, NoDirection);
+}
+
+TEST_F(EncodersTest, test_getCarriage) {
+    Carriage_t c = e.getCarriage();
+    ASSERT_EQ(c, NoCarriage);
+}
+
+TEST_F(EncodersTest, test_getHallValue) {
+    uint16 v = e.getHallValue(NoDirection);
+    ASSERT_EQ(v, 0u);
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L));
+    v = e.getHallValue(Left);
+    ASSERT_EQ(v, 0u);
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R));
+    v = e.getHallValue(Right);
+    ASSERT_EQ(v, 0u);
+    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
+        .WillOnce(Return(0xdeadbeefu));
+    v = e.getHallValue(Right);
+    ASSERT_EQ(v, 0xdeadbeefu);
 }


### PR DESCRIPTION
Added tests for encoders, line coverage is 93% and branch coverage is 75%, this can obviously be improved.

I made tiny changes to the code itself to make it easier to test (see changes in settings.h and encoders.cpp/encoders.h).

The test/README.md file should guide developers in setting up the test environment and running tests.