### PR TITLE
Fix for https://github.com/AllYarnsAreBeautiful/ayab-firmware/issues/48

### DIFF
--- a/encoders.cpp
+++ b/encoders.cpp
@@ -50,7 +50,7 @@ void Encoders::encA_interrupt() {
  * PRIVATE METHODS
  */ 
 void Encoders::encA_rising() {
-  // Direction only decided on rising edge of encoder A
+  // Update direction
   m_direction = digitalRead(ENC_PIN_B) ? Right : Left;
 
   // Update carriage position
@@ -87,6 +87,9 @@ void Encoders::encA_rising() {
 
 
 void Encoders::encA_falling() {
+  // Update direction
+  m_direction = digitalRead(ENC_PIN_B) ? Left : Right;
+
   // Update carriage position
   if (Left == m_direction) {
     if (m_encoderPos > END_LEFT) {


### PR DESCRIPTION
EncA & EncB states are directly/mechanically related to the carriage position, i.e. change of the carriage position should always align with the same EncA & EncB states for both directions.

In the drawing below and with the current implementation (top), you can see that for a right->left turnaround:

- (top left) when the change of direction occurs after a EncA negedge everything is fine; negedge becomes a posedge after turnround, direction is therefore updated and next negedge counts down at the right time.

- (top right) when the change of direction occurs after a EncA posedge something wrong happens; posedge becomes a negedge after turnaround, direction is therefore NOT updated until the next posedge and position counts down only after the following negedge, i.e. too late.

If the position is also updated upon EncA negedge (bottom drawings), position is correct in both cases.

![218340218-f14372d1-05ad-4fdf-bd1d-90dbeb6ec9e5](https://user-images.githubusercontent.com/40644331/218581850-237d41c9-5f79-4b8d-b47e-a2467171328a.png)

For a left->right turnaround, there are no issues as direction is always correct at the first posedge/when position has to be incremented with both current (and patched) implementation, i.e. drift is always to the right.