### PR TITLE
Update v1.0-dev branch with recent changes from main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to AYAB
+
+Please follow this [link](https://raw.githubusercontent.com/AllYarnsAreBeautiful/ayab-desktop/master/CONTRIBUTING.md).

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -126,7 +126,7 @@ Machine_t Encoders::getMachineType() {
  * Bounds on `m_machineType` not checked.
  */
 void Encoders::encA_rising() {
-  // Direction only decided on rising edge of encoder A
+  // Update direction
   m_direction = digitalRead(ENC_PIN_B) != 0 ? Right : Left;
 
   // Update carriage position
@@ -188,6 +188,9 @@ void Encoders::encA_rising() {
  * Bounds on `m_machineType` not checked.
  */
 void Encoders::encA_falling() {
+  // Update direction
+  m_direction = digitalRead(ENC_PIN_B) ? Left : Right;
+
   // Update carriage position
   if (Left == m_direction) {
     if (m_position > END_LEFT[m_machineType]) {


### PR DESCRIPTION
This pulls in the fix from #48 as well as the `contributing.md` document. I chose to cherry-pick over a merge or rebase, as the changes from a489694 cause a whole heap of merge conflicts.
If one instead wishes to perform a rebase or merge to obtain these changes, reverting a489694 on master beforehand avoids the majority of merge conflict madness. That flow for me was pretty simple, with almost no issues:
```
git switch master
git revert a489694
git switch v1.0-dev
git rebase master
```