### PR TITLE
Fix test running, add Test Results parsing

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [push, pull_request]
 
+permissions:
+  checks: write
+  pull-requests: write
 jobs:
   run-test:
     runs-on: ubuntu-latest
@@ -20,3 +23,9 @@ jobs:
     - name: Run Test
       run: |
         ./test/test.sh
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          ./test/build/xml_out/*

--- a/src/ayab/solenoids.cpp
+++ b/src/ayab/solenoids.cpp
@@ -103,10 +103,10 @@ void Solenoids::write(uint16_t newState) {
   mcp_1.writeGPIO(highByte(newState));
 #elif defined SOFT_I2C
   SoftI2C.beginTransmission(I2Caddr_sol1_8 | SOLENOIDS_I2C_ADDRESS_MASK);
-  SoftI2C.send(lowByte(newState));
+  SoftI2C.write(lowByte(newState));
   SoftI2C.endTransmission();
   SoftI2C.beginTransmission(I2Caddr_sol9_16 | SOLENOIDS_I2C_ADDRESS_MASK);
-  SoftI2C.send(highByte(newState));
+  SoftI2C.write(highByte(newState));
   SoftI2C.endTransmission();
 #endif
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,10 +79,10 @@ set(COMMON_FLAGS
     -g -Og
     )
 set(COMMON_LINKER_FLAGS
-    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/gtest/libgtest.a
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/lib/libgtest.a
     # For some reason the order of libarduinomock and libgmock matter, keep them this way.
     ${ARDUINO_MOCK_LIBS_DIR}/dist/lib/libarduino_mock.a
-    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/googlemock/libgmock.a
+    ${ARDUINO_MOCK_LIBS_DIR}/lib/gtest/gtest/src/gtest-build/lib/libgmock.a
     ${CMAKE_THREAD_LIBS_INIT}
     -lgcov
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.18.0)
 project(ayab_test)
 
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard to be used for compiling")
@@ -183,9 +183,9 @@ target_link_libraries(${PROJECT_NAME}_knitter
 )
 add_dependencies(${PROJECT_NAME}_knitter arduino_mock)
 
-# TODO(sl): Use gtest_discover_tests() ?
-# https://cmake.org/cmake/help/git-master/module/GoogleTest.html
 enable_testing()
-add_test(test_Uno ${PROJECT_NAME}_Uno)
-add_test(test_Mega ${PROJECT_NAME}_Mega)
-add_test(test_knitter ${PROJECT_NAME}_knitter)
+include(GoogleTest)
+gtest_discover_tests(${PROJECT_NAME}_Uno TEST_PREFIX Uno_ XML_OUTPUT_DIR ./xml_out)
+gtest_discover_tests(${PROJECT_NAME}_Mega TEST_PREFIX Mega_ XML_OUTPUT_DIR ./xml_out)
+gtest_discover_tests(${PROJECT_NAME}_knitter TEST_PREFIX Knitter_ XML_OUTPUT_DIR ./xml_out)
+

--- a/test/arduino_mock/CMakeLists.txt
+++ b/test/arduino_mock/CMakeLists.txt
@@ -3,7 +3,7 @@ project(arduino_mock_builder C CXX)
 include(ExternalProject)
 
 ExternalProject_Add(arduino_mock
-    GIT_REPOSITORY https://github.com/bt-trx/arduino-mock
+    GIT_REPOSITORY https://github.com/X-sam/arduino-mock
     GIT_TAG bt-trx
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/arduino_mock
     INSTALL_COMMAND ""

--- a/test/arduino_mock/CMakeLists.txt
+++ b/test/arduino_mock/CMakeLists.txt
@@ -3,7 +3,7 @@ project(arduino_mock_builder C CXX)
 include(ExternalProject)
 
 ExternalProject_Add(arduino_mock
-    GIT_REPOSITORY https://github.com/X-sam/arduino-mock
+    GIT_REPOSITORY https://github.com/AllYarnsAreBeautiful/arduino-mock
     GIT_TAG bt-trx
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/arduino_mock
     INSTALL_COMMAND ""


### PR DESCRIPTION
This addresses the test running issues brought up in #54 but it does _NOT_ address failing tests.  
If anyone has access to the [bt-trx fork of `arduino-mock`](https://github.com/bt-trx/arduino-mock) then updating that might be more sensible than using my new fork here- I only added minimal changes to update the gtest dependency version.

This PR also adds some high-level reporting for test failures, both in PRs and the actions interface. Hopefully this helps make it easier to identify regressions and fix issues.
![image](https://user-images.githubusercontent.com/6620407/221426276-5ef927df-3ac2-441d-82a2-2f1647ec483b.png)
