### PR TITLE
update builder, add archive

### DIFF
--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -8,23 +8,18 @@ jobs:
 
     steps:
     - name: Checkout repo and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Install dependencies
       run: |
         sudo apt-get install arduino-mk
-    - name: Prepare
-      run: |
-        export ARDMK_DIR=$(dirname $(find /usr -name Arduino.mk))
-        export ARDUINO_DIR=$ARDMK_DIR
     - name: Build
       run: |
         ./build.sh
         ls build
-    - name: Archive
-      run: |
-        cd build
-        zip ayab-firmware.zip ./*
-        pwd
-        ls
+    - name: Archive Build
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{format('{0}-{1}',github.sha,github.run_number)}}
+        path: build/*.hex


### PR DESCRIPTION
This lets github action builds get stored, so folks can download test versions of firmware without needing a local build environment.
![image](https://user-images.githubusercontent.com/6620407/224583358-0766e6ed-1706-4878-9667-dfcd68c1c0da.png)
