### PR TITLE
v1.0 dev workflow job to create release assets 

### DIFF
--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -63,10 +63,5 @@ jobs:
         draft: ${{ steps.vars.outputs.draft }}
         prerelease: false
         allowUpdates: true
-        artifacts: AYAB-firmware-${{ steps.vars.outputs.tag }}
+        artifacts: build/*.hex
         replacesArtifacts: true
-    - name: Upload asset
-      uses: actions/upload-artifact@v3
-      with:
-        name: AYAB-firmware-${{ steps.vars.outputs.tag }}
-        path: build/*.hex

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -18,6 +18,11 @@ jobs:
       run: |
         ./build.sh
         ls build
+    - name: Cache build asset
+      uses: actions/cache/save@v3
+      with:
+        path: build/*.hex
+        key: build-${{ hashFiles('build/*.hex') }}
     - name: Archive Build
       uses: actions/upload-artifact@v3
       with:
@@ -39,6 +44,13 @@ jobs:
         echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
         echo "draft=$(git describe --tags | sed -e 's/^test.*/true/;s/^v.*/false/')" >> $GITHUB_OUTPUT
+    - name: Restore cached asset
+      id:   restore-cache
+      uses: actions/cache@v3
+      with:
+        path: build/*.hex
+        key:  build-${{ hashFiles('build/*.hex') }}
+        fail-on-cache-miss: true
     - name: Create release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -23,3 +23,37 @@ jobs:
       with:
         name: ${{format('{0}-{1}',github.sha,github.run_number)}}
         path: build/*.hex
+
+  build-release:
+    if:  ${{ (github.event_name == 'push') && (github.ref_type == 'tag') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name == 'test')) }}
+    needs: build-firmware
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Set variables
+      id: vars
+      run: |
+        echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
+        echo "draft=$(git describe --tags | sed -e 's/^test.*/true/;s/^v.*/false/')" >> $GITHUB_OUTPUT
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ steps.vars.outputs.tag }}
+        name: Release ${{ steps.vars.outputs.tag }}
+        commit: ${{ steps.vars.outputs.sha }}
+        body: ""  # release message, alternative to body_path
+        # body_path: release_text.md  # uncomment if not used
+        draft: ${{ steps.vars.outputs.draft }}
+        prerelease: false
+        allowUpdates: true
+        replacesArtifacts: false
+    - name: Upload asset
+      uses: actions/upload-artifact@v3
+      with:
+        name: AYAB-firmware-${{ steps.vars.outputs.tag }}
+        path: build/*.hex

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -29,7 +29,7 @@ jobs:
         name: ${{format('{0}-{1}',github.sha,github.run_number)}}
         path: build/*.hex
 
-  build-release:
+  release-firmware:
     if:  ${{ (github.event_name == 'push') && (github.ref_type == 'tag') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'test')) }}
     needs: build-firmware
     runs-on: ubuntu-latest
@@ -63,7 +63,8 @@ jobs:
         draft: ${{ steps.vars.outputs.draft }}
         prerelease: false
         allowUpdates: true
-        replacesArtifacts: false
+        artifacts: AYAB-firmware-${{ steps.vars.outputs.tag }}
+        replacesArtifacts: true
     - name: Upload asset
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -25,7 +25,7 @@ jobs:
         path: build/*.hex
 
   build-release:
-    if:  ${{ (github.event_name == 'push') && (github.ref_type == 'tag') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name == 'test')) }}
+    if:  ${{ (github.event_name == 'push') && (github.ref_type == 'tag') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'test')) }}
     needs: build-firmware
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Creates a release and uploads artifacts from build/*.hex

Job is activated when a tag is pushed that begins with 'v' or 'test'

Something like this is necessary so that the desktop software can grab the build assets from the latest release.