### PR TITLE
remove redundant preprocessor instructions in solenoids.cpp and test_solenoids.cpp

### DIFF
--- a/src/ayab/solenoids.cpp
+++ b/src/ayab/solenoids.cpp
@@ -27,12 +27,8 @@
 
 /*!
  * Initialize I2C connection for solenoids.
- *
- * TP 2023/05/18: the preprocessor instructions seem redundant,
- * but uno_SolenoidsTest.test_init segfaults if it is removed
  */
 void Solenoids::init() {
-#ifdef HARD_I2C
   mcp_0.begin(I2Caddr_sol1_8);
   mcp_1.begin(I2Caddr_sol9_16);
 
@@ -40,8 +36,6 @@ void Solenoids::init() {
     mcp_0.pinMode(i, OUTPUT);
     mcp_1.pinMode(i, OUTPUT);
   }
-#endif
-  // No Action needed for SOFT_I2C
   solenoidState = 0x0000U;
 }
 

--- a/test/test_solenoids.cpp
+++ b/test/test_solenoids.cpp
@@ -24,9 +24,7 @@
 #include <gtest/gtest.h>
 
 #include <solenoids.h>
-#ifdef HARD_I2C
 #include <Wire.h>
-#endif
 
 using ::testing::Return;
 
@@ -36,9 +34,7 @@ class SolenoidsTest : public ::testing::Test {
 protected:
   void SetUp() override {
     arduinoMock = arduinoMockInstance();
-#ifdef HARD_I2C
     wireMock = WireMockInstance();
-#endif
   }
 
   void TearDown() override {
@@ -46,9 +42,7 @@ protected:
   }
 
   ArduinoMock *arduinoMock;
-#ifdef HARD_I2C
   WireMock *wireMock;
-#endif
 };
 
 TEST_F(SolenoidsTest, test_construct) {


### PR DESCRIPTION
Addressing https://github.com/AllYarnsAreBeautiful/ayab-firmware/issues/74