### PR TITLE
some tweaks to test scripts

### DIFF
--- a/src/ayab/beeper.cpp
+++ b/src/ayab/beeper.cpp
@@ -54,7 +54,7 @@ void Beeper::endWork() {
 /*!
  * Generic beep function.
  *
- * @param length number of beeps
+ * /param length number of beeps
  */
 void Beeper::beep(uint8_t length) {
 

--- a/src/ayab/solenoids.h
+++ b/src/ayab/solenoids.h
@@ -64,6 +64,7 @@ public:
 
 class Solenoids : public SolenoidsInterface {
 #ifdef AYAB_TESTS
+  FRIEND_TEST(SolenoidsTest, test_init);
   FRIEND_TEST(SolenoidsTest, test_setSolenoid1);
   FRIEND_TEST(SolenoidsTest, test_setSolenoid2);
   FRIEND_TEST(SolenoidsTest, test_setSolenoid3);

--- a/test/test_beeper.cpp
+++ b/test/test_beeper.cpp
@@ -41,26 +41,26 @@ protected:
   }
 
   void checkBeepTime(uint8_t length) {
-    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, 0)).Times(length);
-    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, 20)).Times(length);
+    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, BEEP_ON_DUTY)).Times(length);
+    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, BEEP_OFF_DUTY)).Times(length);
     EXPECT_CALL(*arduinoMock, delay(BEEP_DELAY)).Times(length * 2);
-    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, 255)).Times(1);
+    EXPECT_CALL(*arduinoMock, analogWrite(PIEZO_PIN, BEEP_NO_DUTY)).Times(1);
   }
 
   ArduinoMock *arduinoMock;
 };
 
 TEST_F(BeeperTest, test_ready) {
-  checkBeepTime(5);
+  checkBeepTime(BEEP_NUM_READY);
   beeper->ready();
 }
 
 TEST_F(BeeperTest, test_finishedLine) {
-  checkBeepTime(3);
+  checkBeepTime(BEEP_NUM_FINISHEDLINE);
   beeper->finishedLine();
 }
 
 TEST_F(BeeperTest, test_endWork) {
-  checkBeepTime(10);
+  checkBeepTime(BEEP_NUM_ENDWORK);
   beeper->endWork();
 }

--- a/test/test_solenoids.cpp
+++ b/test/test_solenoids.cpp
@@ -50,6 +50,7 @@ TEST_F(SolenoidsTest, test_construct) {
 
 TEST_F(SolenoidsTest, test_init) {
   solenoids->init();
+  ASSERT_TRUE(solenoids->solenoidState == 0U);
 }
 
 TEST_F(SolenoidsTest, test_setSolenoid1) {


### PR DESCRIPTION
Comment out some calls to SerialMock methods.

Rewrite a couple of tests of Com::h_reqInit. which still need SerialPacket to be mocked.

Replace some constant values with named constants in test_beeper.cpp.