### PR TITLE
Update garter carriage values for 910

### DIFF
--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -213,7 +213,11 @@ void Encoders::encA_falling() {
   if (hallValueSmall || hallValue > FILTER_R_MAX[m_machineType]) {
     m_hallActive = Right;
 
-    if (hallValueSmall) {
+
+    // The garter carriage has a second set of magnets that are going to 
+    // pass the sensor and will reset state incorrectly if allowed to
+    // continue.
+    if (hallValueSmall && m_carriage != Garter) {
       m_carriage = Knit;
     }
 

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -63,14 +63,14 @@ constexpr uint8_t END_LEFT[NUM_MACHINES] = {0U, 0U, 0U};
 constexpr uint8_t END_RIGHT[NUM_MACHINES] = {255U, 255U, 140U};
 constexpr uint8_t END_OFFSET[NUM_MACHINES] = {28U, 28U, 14U};
 
-constexpr uint8_t GARTER_SLOP = 14;
+constexpr uint8_t GARTER_SLOP = 2;
 
 constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
     // KH910
     {
         //   K,  L,  G
-        {40, 40, 8}, // Left
-        {16, 16, 32} // Right
+        {40, 40, 32}, // Left
+        {16, 16, 56} // Right
     },
     // KH930
     {


### PR DESCRIPTION
- Reduce the slop for second magnet checking
- Update the offsets now that we have the machine set before figuring out carriage.
- Prevent the carriage type from being reset in encA_falling

This should also fix the delayed start bug: https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/524