### PR TITLE
Update build_firmware.yml

### DIFF
--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build for Arduino UNO
       run: |
         platformio run --environment uno
-        mkdir build
+        mkdir -p build
         mv .pio/build/uno/firmware.hex build/ayab_monolithic_uno.hex
     - name: Cache build asset
       uses: actions/cache/save@v3


### PR DESCRIPTION
`mkdir -p` won't throw an error message if the folder already exists