### PR TITLE
[DRAFT] make platformio firmware build flashable from desktop ui

### DIFF
--- a/fix-build-name.py
+++ b/fix-build-name.py
@@ -1,0 +1,6 @@
+import shutil, os
+Import("env")
+
+env.Replace(PROGNAME = "ayab_monolithic_uno")
+shutil.copy(os.getcwd()+"/.pio/build/uno/ayab_monolithic_uno.hex", 
+    "/Applications/AYAB.app/Contents/Resources/ayab/firmware/ayab_monolithic_uno.hex")

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,9 +11,9 @@
 [platformio]
 default_envs = uno
 
-[env]
-framework = arduino
-
 [env:uno]
-platform = atmelavr
 board = uno
+framework = arduino
+platform = atmelavr
+extra_scripts = pre:fix-build-name.py
+


### PR DESCRIPTION
Not final implementation:
PlatformIO supports running small scripts after builds. We can use this to rename the firmware and place to the AYAB software dir, so that the desktop software can flash this without any changes.

Big question: how to handle firmware path for different OS? Maybe we can add some AYAB_FIRMWARE_PATH environment variable to make it easier to find. Or we can just do some switch statement in the script to check the OS, but this is a little messy IMO.