### PR TITLE
Report git tag as fw version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build*
 *.pu
 html
 *.swp
+
+src/ayab/version.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,8 @@ default_envs = uno
 
 [env]
 framework = arduino
+extra_scripts = 
+    pre:scripts/preBuild.py 
 
 [env:uno]
 platform = atmelavr

--- a/scripts/preBuild.py
+++ b/scripts/preBuild.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import re
+
+Import("env")
+print("Pre build script")
+
+# Reads the current git tag of the repo and returns the version number 
+# elements
+# In case there are changes since the last tag, the dirty flag is set
+# In case the git tag does not match the x.y.z format, 0.0.0 is used as fallback
+def git_version():
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for k in ['SYSTEMROOT', 'PATH']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.Popen(cmd, stdout = subprocess.PIPE, env=env, shell=True).communicate()[0]
+        return out
+
+    fw_maj = "0"
+    fw_min = "0"
+    fw_patch = "0"
+    fw_dirty = "0"
+
+    try:
+        out = _minimal_ext_cmd("git describe --tags")
+        version_string = out.strip().decode('ascii')
+        print(version_string)
+
+        # Check if string matches the version format 0.0.0-...
+        regex = r'\d{,3}[.]\d{1,3}[.]\d{1,3}'
+
+        pattern = re.compile(regex)
+        match = pattern.match(version_string)
+
+        if match:
+            fw_maj, fw_min, tail = version_string.split('.')
+            tail = tail.split('-')
+            fw_patch = tail[0]
+            if len(tail) > 1:
+                fw_dirty = "1"
+    except OSError:
+        pass
+
+    return fw_maj, fw_min, fw_patch, fw_dirty
+
+fw_maj, fw_min, fw_patch, fw_dirty = git_version()
+print("GIT Version: " + fw_maj + "." + fw_min + "." + fw_patch + " dirty:" + fw_dirty)
+
+with open("src/ayab/version.h", "w") as text_file:
+    text_file.write("constexpr uint8_t FW_VERSION_MAJ = {0}U;\n".format(fw_maj))
+    text_file.write("constexpr uint8_t FW_VERSION_MIN = {0}U;\n".format(fw_min))
+    text_file.write("constexpr uint8_t FW_VERSION_PATCH = {0}U;\n".format(fw_patch))
+    text_file.write("constexpr uint8_t FW_VERSION_DIRTY = {0}U;\n".format(fw_dirty))

--- a/scripts/preBuild.py
+++ b/scripts/preBuild.py
@@ -27,7 +27,7 @@ def git_version():
     fw_maj = "0"
     fw_min = "0"
     fw_patch = "0"
-    fw_dirty = "0"
+    fw_suffix = ""
 
     try:
         out = _minimal_ext_cmd("git describe --tags")
@@ -42,20 +42,21 @@ def git_version():
 
         if match:
             fw_maj, fw_min, tail = version_string.split('.')
-            tail = tail.split('-')
+            tail = tail.split('-', 1)
             fw_patch = tail[0]
             if len(tail) > 1:
-                fw_dirty = "1"
+                # Maximum length of suffix: 16 characters
+                fw_suffix = tail[1][:16]
     except OSError:
         pass
 
-    return fw_maj, fw_min, fw_patch, fw_dirty
+    return fw_maj, fw_min, fw_patch, fw_suffix
 
-fw_maj, fw_min, fw_patch, fw_dirty = git_version()
-print("GIT Version: " + fw_maj + "." + fw_min + "." + fw_patch + " dirty:" + fw_dirty)
+fw_maj, fw_min, fw_patch, fw_suffix = git_version()
+print("GIT Version: " + fw_maj + "." + fw_min + "." + fw_patch + "-" + fw_suffix)
 
 with open("src/ayab/version.h", "w") as text_file:
     text_file.write("constexpr uint8_t FW_VERSION_MAJ = {0}U;\n".format(fw_maj))
     text_file.write("constexpr uint8_t FW_VERSION_MIN = {0}U;\n".format(fw_min))
     text_file.write("constexpr uint8_t FW_VERSION_PATCH = {0}U;\n".format(fw_patch))
-    text_file.write("constexpr uint8_t FW_VERSION_DIRTY = {0}U;\n".format(fw_dirty))
+    text_file.write("constexpr char  FW_VERSION_SUFFIX[] = \"{0}\";\n".format(fw_suffix))

--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -349,14 +349,15 @@ void Com::h_unrecognized() {
  * \brief Send `cnfInfo` message.
  */
 void Com::send_cnfInfo() {
-  uint8_t payload[6];
+  // Max. length of suffix string: 16 bytes + \0
+  uint8_t payload[22];
   payload[0] = cnfInfo_msgid;
   payload[1] = API_VERSION;
   payload[2] = FW_VERSION_MAJ;
   payload[3] = FW_VERSION_MIN;
   payload[4] = FW_VERSION_PATCH;
-  payload[5] = FW_VERSION_DIRTY;
-  send(payload, 6);
+  strncpy((char*)payload + 5, FW_VERSION_SUFFIX, 16);
+  send(payload, 22);
 }
 
 /*!

--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -349,12 +349,14 @@ void Com::h_unrecognized() {
  * \brief Send `cnfInfo` message.
  */
 void Com::send_cnfInfo() {
-  uint8_t payload[4];
+  uint8_t payload[6];
   payload[0] = cnfInfo_msgid;
   payload[1] = API_VERSION;
   payload[2] = FW_VERSION_MAJ;
   payload[3] = FW_VERSION_MIN;
-  send(payload, 4);
+  payload[4] = FW_VERSION_PATCH;
+  payload[5] = FW_VERSION_DIRTY;
+  send(payload, 6);
 }
 
 /*!

--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -30,7 +30,14 @@
 #include "encoders.h"
 #include "fsm.h"
 
-#include "version.h"
+#ifndef AYAB_TESTS
+  #include "version.h"
+#else
+  constexpr uint8_t FW_VERSION_MAJ = 0U;
+  constexpr uint8_t FW_VERSION_MIN = 0U;
+  constexpr uint8_t FW_VERSION_PATCH = 0U;
+  constexpr uint8_t FW_VERSION_DIRTY = 0U;
+#endif // AYAB_TESTS
 
 constexpr uint8_t API_VERSION = 6U;
 

--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -30,9 +30,7 @@
 #include "encoders.h"
 #include "fsm.h"
 
-constexpr uint8_t FW_VERSION_MAJ = 1U;
-constexpr uint8_t FW_VERSION_MIN = 0U;
-constexpr uint8_t FW_VERSION_PATCH = 0U;
+#include "version.h"
 
 constexpr uint8_t API_VERSION = 6U;
 

--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -36,7 +36,7 @@
   constexpr uint8_t FW_VERSION_MAJ = 0U;
   constexpr uint8_t FW_VERSION_MIN = 0U;
   constexpr uint8_t FW_VERSION_PATCH = 0U;
-  constexpr uint8_t FW_VERSION_DIRTY = 0U;
+  constexpr char FW_VERSION_SUFFIX[] = "";
 #endif // AYAB_TESTS
 
 constexpr uint8_t API_VERSION = 6U;


### PR DESCRIPTION
Implements changes to report the firmware version in cnfInfo according to the current git tag.

- The git tag has to be in the format x.y.z, where x,y,z are 1-3 digits. (as defined by semver.org).
- In case the git tag does not match this format, 0.0.0 is used.
- In case there have been changes since the tag was applied (indicated by an appendix in the version string by `git describe --tags`, for example "1.0.0-4-gc5abe8c", the "dirty" flag is set to indicate that the software does as been altered.

Still to do (any help appreciated!):

- [x] Fix firmware unit tests (dynamically generated version.h is missing in case of running unit tests standalone)

- [x] Update the APIv6 spec in ayab-manual. *cnfInfo* consists now of 6 bytes. PR: https://github.com/AllYarnsAreBeautiful/ayab-manual/pull/27

```
payload[0] = cnfInfo_msgid;
payload[1] = API_VERSION;
payload[2] = FW_VERSION_MAJ;
payload[3] = FW_VERSION_MIN;
payload[4] = FW_VERSION_PATCH;
payload[5] = FW_VERSION_DIRTY;
```

- [x] Update the relevant code in ayab-desktop to parse the FW_VERSION_PATCH and FW_VERSION_DIRTY flags when receiving cnfInfo, PR: https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/550
- [x] Test whether the preBuild.py runs properly on Linux, Windows and Mac

