### PR TITLE
Make the 270 a first class citizen

### DIFF
--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -146,6 +146,11 @@ void Encoders::encA_rising() {
     return;
   }
 
+  // If the carriage is already set, ignore the rest.
+  if (m_carriage == Knit && m_machineType == Kh270) {
+    return;
+  }
+
   // In front of Left Hall Sensor?
   uint16_t hallValue = analogRead(EOL_PIN_L);
   if ((hallValue < FILTER_L_MIN[m_machineType]) ||
@@ -164,10 +169,9 @@ void Encoders::encA_rising() {
     if (m_machineType == Kh270) {
       m_carriage = Knit;
 
-      // The 270 carriage has two magnets. If we're past the start_position then we've 
-      // already seen the first one and don't need to do the rest of setup.
-      if (m_position > start_position) {
-        return;
+      // The first magnet on the carriage looks like Lace, the second looks like Knit
+      if (detected_carriage == Knit) {
+        start_position = start_position + MAGNET_DISTANCE_270;
       }
     } else if (m_carriage == NoCarriage) {
       m_carriage = detected_carriage;

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -54,14 +54,14 @@ using BeltShift_t = enum BeltShift;
 
 // Machine constants
 
-constexpr uint8_t NUM_NEEDLES[NUM_MACHINES] = {200U, 200U, 114U};
-constexpr uint8_t LINE_BUFFER_LEN[NUM_MACHINES] = {25U, 25U, 15U};
+constexpr uint8_t NUM_NEEDLES[NUM_MACHINES] = {200U, 200U, 112U};
+constexpr uint8_t LINE_BUFFER_LEN[NUM_MACHINES] = {25U, 25U, 14U};
 constexpr uint8_t END_OF_LINE_OFFSET_L[NUM_MACHINES] = {12U, 12U, 6U};
 constexpr uint8_t END_OF_LINE_OFFSET_R[NUM_MACHINES] = {12U, 12U, 6U};
 
 constexpr uint8_t END_LEFT[NUM_MACHINES] = {0U, 0U, 0U};
 constexpr uint8_t END_RIGHT[NUM_MACHINES] = {255U, 255U, 140U};
-constexpr uint8_t END_OFFSET[NUM_MACHINES] = {28U, 28U, 14U};
+constexpr uint8_t END_OFFSET[NUM_MACHINES] = {28U, 28U, 5U};
 
 // The garter slop is needed to determine whether or not we have a garter carriage.
 // If we didn't have it, we'd decide which carriage we had when the first magnet passed the sensor.
@@ -84,20 +84,22 @@ constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
     // KH270
     {
         // K
-        {27U, 0U, 0U}, // Left
-        {15U, 0U, 0U}   // Right
+        {28U, 0U, 0U}, // Left: x % 12 == 4
+        {16U, 0U, 0U}   // Right: (x + 6) % 12 == 10
     }};
 
 // Should be calibrated to each device
 // Below filter minimum -> Lace carriage
 // Above filter maximum -> Knit carriage
 //                                               KH910 KH930 KH270
-constexpr uint16_t FILTER_L_MIN[NUM_MACHINES] = { 200U, 200U, 400U};
+constexpr uint16_t FILTER_L_MIN[NUM_MACHINES] = { 200U, 200U, 200U};
 constexpr uint16_t FILTER_L_MAX[NUM_MACHINES] = { 600U, 600U, 600U};
 constexpr uint16_t FILTER_R_MIN[NUM_MACHINES] = { 200U,   0U,   0U};
 constexpr uint16_t FILTER_R_MAX[NUM_MACHINES] = {1023U, 600U, 600U};
 
 constexpr uint16_t SOLENOIDS_BITMASK = 0xFFFFU;
+
+constexpr uint8_t MAGNET_DISTANCE_270 = 12U;
 
 /*!
  * \brief Encoder interface.

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -357,7 +357,11 @@ bool Knitter::setNextLine(uint8_t lineNumber) {
     // FIXME: Is there even a need for a new line?
     if (lineNumber == m_currentLineNumber) {
       m_lineRequested = false;
-      //GlobalBeeper::finishedLine();
+
+      // Beeper is causing problems with flanking needles on the 270
+      if (m_machineType != Kh270) {
+        GlobalBeeper::finishedLine();
+      }
       success = true;
     } else {
       // line numbers didn't match -> request again

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -79,6 +79,7 @@ void Knitter::init() {
   m_position = 0U;
   m_hallActive = NoDirection;
   m_pixelToSet = 0;
+  m_lastPixel = 0;
 #ifdef DBG_NOMACHINE
   m_prevState = false;
 #endif
@@ -283,33 +284,23 @@ void Knitter::knit() {
     return;
   }
 
-  // `m_machineType` has been validated - no need to check
-  if ((m_pixelToSet >= m_startNeedle - END_OF_LINE_OFFSET_L[m_machineType]) &&
-      (m_pixelToSet <= m_stopNeedle + END_OF_LINE_OFFSET_R[m_machineType])) {
+  // Desktop software is setting flanking needles so we need to set
+  // these even outside of the working needles.
+  // find the right byte from the currentLine array,
+  // then read the appropriate Pixel(/Bit) for the current needle to set
+  uint8_t currentByte = m_pixelToSet >> 3;
+  bool pixelValue =
+      bitRead(m_lineBuffer[currentByte], m_pixelToSet & 0x07);
+  // write Pixel state to the appropriate needle
+  GlobalSolenoids::setSolenoid(m_solenoidToSet, pixelValue);
 
-    if ((m_pixelToSet >= m_startNeedle) && (m_pixelToSet <= m_stopNeedle)) {
-      // when inside the active needles
-      if (m_machineType == Kh270) {
-        digitalWrite(LED_PIN_B, 1); // yellow LED on
-      }
-      m_workedOnLine = true;
-    }
+  if ((m_pixelToSet >= m_startNeedle) && (m_pixelToSet <= m_stopNeedle)) {
+    m_workedOnLine = true;
+  }
 
-    // find the right byte from the currentLine array,
-    // then read the appropriate Pixel(/Bit) for the current needle to set
-    uint8_t currentByte = m_pixelToSet >> 3;
-    bool pixelValue =
-        bitRead(m_lineBuffer[currentByte], m_pixelToSet & 0x07);
-    // write Pixel state to the appropriate needle
-    GlobalSolenoids::setSolenoid(m_solenoidToSet, pixelValue);
-  } else {
+  if ((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[m_machineType]) ||
+      (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[m_machineType])) {
     // outside of the active needles
-    if (m_machineType == Kh270) {
-      digitalWrite(LED_PIN_B, 0); // yellow LED off
-    }
-
-    // reset solenoids when out of range
-    GlobalSolenoids::setSolenoid(m_solenoidToSet, true);
 
     if (m_workedOnLine) {
       // already worked on the current line -> finished the line
@@ -366,7 +357,7 @@ bool Knitter::setNextLine(uint8_t lineNumber) {
     // FIXME: Is there even a need for a new line?
     if (lineNumber == m_currentLineNumber) {
       m_lineRequested = false;
-      GlobalBeeper::finishedLine();
+      //GlobalBeeper::finishedLine();
       success = true;
     } else {
       // line numbers didn't match -> request again
@@ -420,18 +411,18 @@ bool Knitter::calculatePixelAndSolenoid() {
     if (m_position >= startOffset) {
       m_pixelToSet = m_position - startOffset;
 
+      if (BeltShift::Regular == m_beltShift || m_machineType == Kh270) {
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[m_machineType];
+      } else if (BeltShift::Shifted == m_beltShift) {
+        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[m_machineType]) % SOLENOIDS_NUM[m_machineType];
+      }
+      if (Lace == m_carriage) {
+        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[m_machineType];
+      }
+
+      // The 270 has 12 solenoids but they get shifted over 3 bits
       if (m_machineType == Kh270) {
-        // TODO(who?): check
-        m_solenoidToSet = (m_position % 12) + 3;
-      } else {
-        if (BeltShift::Regular == m_beltShift) {
-          m_solenoidToSet = m_position % SOLENOIDS_NUM;
-        } else if (BeltShift::Shifted == m_beltShift) {
-          m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM) % SOLENOIDS_NUM;
-        }
-        if (Lace == m_carriage) {
-          m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM;
-        }
+        m_solenoidToSet = m_solenoidToSet + 3;
       }
     } else {
       success = false;
@@ -443,18 +434,18 @@ bool Knitter::calculatePixelAndSolenoid() {
     if (m_position <= (END_RIGHT[m_machineType] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 
+      if (BeltShift::Regular == m_beltShift || m_machineType == Kh270) {
+        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[m_machineType]) % SOLENOIDS_NUM[m_machineType];
+      } else if (BeltShift::Shifted == m_beltShift) {
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[m_machineType];
+      }
+      if (Lace == m_carriage) {
+        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[m_machineType];
+      }
+
+      // The 270 has 12 solenoids but they get shifted over 3 bits
       if (m_machineType == Kh270) {
-        // TODO(who?): check
-        m_solenoidToSet = ((m_position + 6) % 12) + 3;
-      } else {
-        if (BeltShift::Regular == m_beltShift) {
-          m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM) % SOLENOIDS_NUM;
-        } else if (BeltShift::Shifted == m_beltShift) {
-          m_solenoidToSet = m_position % SOLENOIDS_NUM;
-        }
-        if (Lace == m_carriage) {
-          m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM;
-        }
+        m_solenoidToSet = m_solenoidToSet + 3;
       }
     } else {
       success = false;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -79,7 +79,6 @@ void Knitter::init() {
   m_position = 0U;
   m_hallActive = NoDirection;
   m_pixelToSet = 0;
-  m_lastPixel = 0;
 #ifdef DBG_NOMACHINE
   m_prevState = false;
 #endif

--- a/src/ayab/knitter.h
+++ b/src/ayab/knitter.h
@@ -141,7 +141,6 @@ private:
   // resulting needle data
   uint8_t m_solenoidToSet;
   uint8_t m_pixelToSet;
-  uint8_t m_lastPixel;
 
 #if AYAB_TESTS
   // Note: ideally tests would only rely on the public interface.

--- a/src/ayab/knitter.h
+++ b/src/ayab/knitter.h
@@ -141,6 +141,7 @@ private:
   // resulting needle data
   uint8_t m_solenoidToSet;
   uint8_t m_pixelToSet;
+  uint8_t m_lastPixel;
 
 #if AYAB_TESTS
   // Note: ideally tests would only rely on the public interface.

--- a/src/ayab/solenoids.cpp
+++ b/src/ayab/solenoids.cpp
@@ -32,7 +32,7 @@ void Solenoids::init() {
   mcp_0.begin(I2Caddr_sol1_8);
   mcp_1.begin(I2Caddr_sol9_16);
 
-  for (int i = 0; i < HALF_SOLENOIDS_NUM; i++) {
+  for (int i = 0; i < SOLENOID_BUFFER_SIZE / 2; i++) {
     mcp_0.pinMode(i, OUTPUT);
     mcp_1.pinMode(i, OUTPUT);
   }
@@ -46,8 +46,8 @@ void Solenoids::init() {
  * \param state The state to set the solenoid to.
  */
 void Solenoids::setSolenoid(uint8_t solenoid, bool state) {
-  if (solenoid > (SOLENOIDS_NUM - 1)) {
-    // Only 16 solenoids (zero-indexed).
+  if (solenoid > (SOLENOID_BUFFER_SIZE - 1)) {
+    // Solenoid buffer is 16 bits (zero-indexed).
     return;
   }
 

--- a/src/ayab/solenoids.h
+++ b/src/ayab/solenoids.h
@@ -25,13 +25,17 @@
 #define SOLENOIDS_H_
 
 #include "board.h"
+#include "encoders.h"
 #include <Arduino.h>
 #include <Adafruit_MCP23008.h>
 #include <Wire.h>
 
-constexpr uint8_t SOLENOIDS_NUM = 16U;
-constexpr uint8_t HALF_SOLENOIDS_NUM = 8U;
+// Different machines have a different number of solenoids.
+//                                              {910, 930, 270}
+constexpr uint8_t SOLENOIDS_NUM[NUM_MACHINES] = {16U, 16U, 12U};
+constexpr uint8_t HALF_SOLENOIDS_NUM[NUM_MACHINES] = {8U, 8U, 6U};
 constexpr uint8_t SOLENOIDS_I2C_ADDRESS_MASK = 0x20U;
+constexpr uint8_t SOLENOID_BUFFER_SIZE = 16U;
 
 class SolenoidsInterface {
 public:

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -444,12 +444,6 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // second knit
-  EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_B, 0))
-      .Times(AtLeast(0)); // yellow LED off
-  EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_B, 1))
-      .Times(AtLeast(1)); // yellow LED on
-  EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_B, 0))
-      .Times(AtLeast(0)); // yellow LED off
   expected_isr(START_NEEDLE);
   expect_indState();
   EXPECT_CALL(*solenoidsMock, setSolenoid);


### PR DESCRIPTION
Corresponding desktop PR: https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/571

In this PR:

- Updates to the 270 constants in encoders.h
  - 114 needles -> 112 needles because the last needles don't pattern
- Set pixels even outside of the working area because the desktop software is now setting "flanking needles"
- Removed LED setting for the 270 when inside of working needles
- Disabled EOL beeper for 270 because it's causing problems setting flanking needles, we can revert this if the proposed beeper scheduling solves this problem.
- Unified calculatePixelAndSolenoid logic
- Updated tests
