### PR TITLE
Using enum class Machine/Carriage/Direction

### DIFF
--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -97,8 +97,8 @@ void Com::send_reqLine(const uint8_t lineNumber, Err_t error) const {
  */
 void Com::send_indState(Carriage_t carriage, uint8_t position,
                         Err_t error) const {
-  uint16_t leftHallValue = GlobalEncoders::getHallValue(Left);
-  uint16_t rightHallValue = GlobalEncoders::getHallValue(Right);
+  uint16_t leftHallValue = GlobalEncoders::getHallValue(Direction_t::Left);
+  uint16_t rightHallValue = GlobalEncoders::getHallValue(Direction_t::Right);
   uint8_t payload[INDSTATE_LEN] = {
       indState_msgid,
       static_cast<uint8_t>(error),

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -133,7 +133,7 @@ void Encoders::encA_rising() {
   m_direction = digitalRead(ENC_PIN_B) != 0 ? Direction_t::Right : Direction_t::Left;
 
   // Update carriage position
-  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<signed char>(m_machineType)])) {
+  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<uint8_t>(m_machineType)])) {
     m_position = m_position + 1;
   }
 
@@ -151,14 +151,14 @@ void Encoders::encA_rising() {
 
   // In front of Left Hall Sensor?
   uint16_t hallValue = analogRead(EOL_PIN_L);
-  if ((hallValue < FILTER_L_MIN[static_cast<signed char>(m_machineType)]) ||
-      (hallValue > FILTER_L_MAX[static_cast<signed char>(m_machineType)])) {
+  if ((hallValue < FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) ||
+      (hallValue > FILTER_L_MAX[static_cast<uint8_t>(m_machineType)])) {
     m_hallActive = Direction_t::Left;
 
     Carriage detected_carriage = Carriage_t::NoCarriage;
-    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<signed char>(m_machineType)];
+    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)];
 
-    if (hallValue >= FILTER_L_MIN[static_cast<signed char>(m_machineType)]) {
+    if (hallValue >= FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) {
       detected_carriage = Carriage_t::Knit;
     } else {
       detected_carriage = Carriage_t::Lace;
@@ -203,7 +203,7 @@ void Encoders::encA_falling() {
   m_direction = digitalRead(ENC_PIN_B) ? Direction_t::Left : Direction_t::Right;
 
   // Update carriage position
-  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<signed char>(m_machineType)])) {
+  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<uint8_t>(m_machineType)])) {
     m_position = m_position - 1;
   }
 
@@ -214,9 +214,9 @@ void Encoders::encA_falling() {
   // by being explicit about that behaviour being expected.
   bool hallValueSmall = false;
 
-  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<signed char>(m_machineType)]);
+  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<uint8_t>(m_machineType)]);
 
-  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<signed char>(m_machineType)]) {
+  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<uint8_t>(m_machineType)]) {
     m_hallActive = Direction_t::Right;
 
     // The garter carriage has a second set of magnets that are going to
@@ -230,6 +230,6 @@ void Encoders::encA_falling() {
     m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Shifted : BeltShift::Regular;
 
     // Known position of the carriage -> overwrite position
-    m_position = END_RIGHT_MINUS_OFFSET[static_cast<signed char>(m_machineType)];
+    m_position = END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)];
   }
 }

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -133,7 +133,7 @@ void Encoders::encA_rising() {
   m_direction = digitalRead(ENC_PIN_B) != 0 ? Direction_t::Right : Direction_t::Left;
 
   // Update carriage position
-  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<int8_t>(m_machineType)])) {
+  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<signed char>(m_machineType)])) {
     m_position = m_position + 1;
   }
 
@@ -151,14 +151,14 @@ void Encoders::encA_rising() {
 
   // In front of Left Hall Sensor?
   uint16_t hallValue = analogRead(EOL_PIN_L);
-  if ((hallValue < FILTER_L_MIN[static_cast<int8_t>(m_machineType)]) ||
-      (hallValue > FILTER_L_MAX[static_cast<int8_t>(m_machineType)])) {
+  if ((hallValue < FILTER_L_MIN[static_cast<signed char>(m_machineType)]) ||
+      (hallValue > FILTER_L_MAX[static_cast<signed char>(m_machineType)])) {
     m_hallActive = Direction_t::Left;
 
     Carriage detected_carriage = Carriage_t::NoCarriage;
-    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<int8_t>(m_machineType)];
+    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<signed char>(m_machineType)];
 
-    if (hallValue >= FILTER_L_MIN[static_cast<int8_t>(m_machineType)]) {
+    if (hallValue >= FILTER_L_MIN[static_cast<signed char>(m_machineType)]) {
       detected_carriage = Carriage_t::Knit;
     } else {
       detected_carriage = Carriage_t::Lace;
@@ -203,7 +203,7 @@ void Encoders::encA_falling() {
   m_direction = digitalRead(ENC_PIN_B) ? Direction_t::Left : Direction_t::Right;
 
   // Update carriage position
-  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<int8_t>(m_machineType)])) {
+  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<signed char>(m_machineType)])) {
     m_position = m_position - 1;
   }
 
@@ -214,9 +214,9 @@ void Encoders::encA_falling() {
   // by being explicit about that behaviour being expected.
   bool hallValueSmall = false;
 
-  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<int8_t>(m_machineType)]);
+  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<signed char>(m_machineType)]);
 
-  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<int8_t>(m_machineType)]) {
+  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<signed char>(m_machineType)]) {
     m_hallActive = Direction_t::Right;
 
     // The garter carriage has a second set of magnets that are going to
@@ -230,6 +230,6 @@ void Encoders::encA_falling() {
     m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Shifted : BeltShift::Regular;
 
     // Known position of the carriage -> overwrite position
-    m_position = END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(m_machineType)];
+    m_position = END_RIGHT_MINUS_OFFSET[static_cast<signed char>(m_machineType)];
   }
 }

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -36,7 +36,7 @@
  * `m_machineType` assumed valid.
  */
 void Encoders::encA_interrupt() {
-  m_hallActive = NoDirection;
+  m_hallActive = Direction_t::NoDirection;
 
   auto currentState = static_cast<bool>(digitalRead(ENC_PIN_A));
 
@@ -133,7 +133,7 @@ void Encoders::encA_rising() {
   m_direction = digitalRead(ENC_PIN_B) != 0 ? Direction_t::Right : Direction_t::Left;
 
   // Update carriage position
-  if ((Right == m_direction) && (m_position < END_RIGHT[static_cast<uint8_t>(m_machineType)])) {
+  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<uint8_t>(m_machineType)])) {
     m_position = m_position + 1;
   }
 
@@ -153,7 +153,7 @@ void Encoders::encA_rising() {
   uint16_t hallValue = analogRead(EOL_PIN_L);
   if ((hallValue < FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) ||
       (hallValue > FILTER_L_MAX[static_cast<uint8_t>(m_machineType)])) {
-    m_hallActive = Left;
+    m_hallActive = Direction_t::Left;
 
     Carriage detected_carriage = Carriage_t::NoCarriage;
     uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)];
@@ -217,7 +217,7 @@ void Encoders::encA_falling() {
   hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<uint8_t>(m_machineType)]);
 
   if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<uint8_t>(m_machineType)]) {
-    m_hallActive = Right;
+    m_hallActive = Direction_t::Right;
 
     // The garter carriage has a second set of magnets that are going to
     // pass the sensor and will reset state incorrectly if allowed to

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -54,9 +54,9 @@ void Encoders::encA_interrupt() {
  */
 uint16_t Encoders::getHallValue(Direction_t pSensor) {
   switch (pSensor) {
-  case Left:
+  case Direction_t::Left:
     return analogRead(EOL_PIN_L);
-  case Right:
+  case Direction_t::Right:
     return analogRead(EOL_PIN_R);
   default:
     return 0;
@@ -70,8 +70,8 @@ uint16_t Encoders::getHallValue(Direction_t pSensor) {
 void Encoders::init(Machine_t machineType) {
   m_machineType = machineType;
   m_position = 0U;
-  m_direction = NoDirection;
-  m_hallActive = NoDirection;
+  m_direction = Direction_t::NoDirection;
+  m_hallActive = Direction_t::NoDirection;
   m_beltShift = BeltShift::Unknown;
   m_carriage = Carriage_t::NoCarriage;
   m_oldState = false;
@@ -130,7 +130,7 @@ Machine_t Encoders::getMachineType() {
  */
 void Encoders::encA_rising() {
   // Update direction
-  m_direction = digitalRead(ENC_PIN_B) != 0 ? Right : Left;
+  m_direction = digitalRead(ENC_PIN_B) != 0 ? Direction_t::Right : Direction_t::Left;
 
   // Update carriage position
   if ((Right == m_direction) && (m_position < END_RIGHT[static_cast<uint8_t>(m_machineType)])) {
@@ -200,7 +200,7 @@ void Encoders::encA_rising() {
  */
 void Encoders::encA_falling() {
   // Update direction
-  m_direction = digitalRead(ENC_PIN_B) ? Left : Right;
+  m_direction = digitalRead(ENC_PIN_B) ? Direction_t::Left : Direction_t::Right;
 
   // Update carriage position
   if ((Left == m_direction) && (m_position > END_LEFT[static_cast<uint8_t>(m_machineType)])) {

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -203,7 +203,7 @@ void Encoders::encA_falling() {
   m_direction = digitalRead(ENC_PIN_B) ? Direction_t::Left : Direction_t::Right;
 
   // Update carriage position
-  if ((Left == m_direction) && (m_position > END_LEFT[static_cast<uint8_t>(m_machineType)])) {
+  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<uint8_t>(m_machineType)])) {
     m_position = m_position - 1;
   }
 

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -133,7 +133,7 @@ void Encoders::encA_rising() {
   m_direction = digitalRead(ENC_PIN_B) != 0 ? Direction_t::Right : Direction_t::Left;
 
   // Update carriage position
-  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<uint8_t>(m_machineType)])) {
+  if ((Direction_t::Right == m_direction) && (m_position < END_RIGHT[static_cast<int8_t>(m_machineType)])) {
     m_position = m_position + 1;
   }
 
@@ -151,14 +151,14 @@ void Encoders::encA_rising() {
 
   // In front of Left Hall Sensor?
   uint16_t hallValue = analogRead(EOL_PIN_L);
-  if ((hallValue < FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) ||
-      (hallValue > FILTER_L_MAX[static_cast<uint8_t>(m_machineType)])) {
+  if ((hallValue < FILTER_L_MIN[static_cast<int8_t>(m_machineType)]) ||
+      (hallValue > FILTER_L_MAX[static_cast<int8_t>(m_machineType)])) {
     m_hallActive = Direction_t::Left;
 
     Carriage detected_carriage = Carriage_t::NoCarriage;
-    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)];
+    uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<int8_t>(m_machineType)];
 
-    if (hallValue >= FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) {
+    if (hallValue >= FILTER_L_MIN[static_cast<int8_t>(m_machineType)]) {
       detected_carriage = Carriage_t::Knit;
     } else {
       detected_carriage = Carriage_t::Lace;
@@ -203,7 +203,7 @@ void Encoders::encA_falling() {
   m_direction = digitalRead(ENC_PIN_B) ? Direction_t::Left : Direction_t::Right;
 
   // Update carriage position
-  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<uint8_t>(m_machineType)])) {
+  if ((Direction_t::Left == m_direction) && (m_position > END_LEFT[static_cast<int8_t>(m_machineType)])) {
     m_position = m_position - 1;
   }
 
@@ -214,9 +214,9 @@ void Encoders::encA_falling() {
   // by being explicit about that behaviour being expected.
   bool hallValueSmall = false;
 
-  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<uint8_t>(m_machineType)]);
+  hallValueSmall = (hallValue < FILTER_R_MIN[static_cast<int8_t>(m_machineType)]);
 
-  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<uint8_t>(m_machineType)]) {
+  if (hallValueSmall || hallValue > FILTER_R_MAX[static_cast<int8_t>(m_machineType)]) {
     m_hallActive = Direction_t::Right;
 
     // The garter carriage has a second set of magnets that are going to
@@ -230,6 +230,6 @@ void Encoders::encA_falling() {
     m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Shifted : BeltShift::Regular;
 
     // Known position of the carriage -> overwrite position
-    m_position = END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)];
+    m_position = END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(m_machineType)];
   }
 }

--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -73,7 +73,7 @@ void Encoders::init(Machine_t machineType) {
   m_direction = NoDirection;
   m_hallActive = NoDirection;
   m_beltShift = BeltShift::Unknown;
-  m_carriage = NoCarriage;
+  m_carriage = Carriage_t::NoCarriage;
   m_oldState = false;
 }
 
@@ -140,12 +140,12 @@ void Encoders::encA_rising() {
   // The garter carriage has a second set of magnets that are going to
   // pass the sensor and will reset state incorrectly if allowed to
   // continue.
-  if (m_carriage == Garter) {
+  if (m_carriage == Carriage_t::Garter) {
     return;
   }
 
   // If the carriage is already set, ignore the rest.
-  if ((m_carriage == Knit) && (m_machineType == Machine_t::Kh270)) {
+  if ((m_carriage == Carriage_t::Knit) && (m_machineType == Machine_t::Kh270)) {
     return;
   }
 
@@ -155,26 +155,26 @@ void Encoders::encA_rising() {
       (hallValue > FILTER_L_MAX[static_cast<uint8_t>(m_machineType)])) {
     m_hallActive = Left;
 
-    Carriage detected_carriage = NoCarriage;
+    Carriage detected_carriage = Carriage_t::NoCarriage;
     uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)];
 
     if (hallValue >= FILTER_L_MIN[static_cast<uint8_t>(m_machineType)]) {
-      detected_carriage = Knit;
+      detected_carriage = Carriage_t::Knit;
     } else {
-      detected_carriage = Lace;
+      detected_carriage = Carriage_t::Lace;
     }
 
     if (m_machineType == Machine_t::Kh270) {
-      m_carriage = Knit;
+      m_carriage = Carriage_t::Knit;
 
       // The first magnet on the carriage looks like Lace, the second looks like Knit
-      if (detected_carriage == Knit) {
+      if (detected_carriage == Carriage_t::Knit) {
         start_position = start_position + MAGNET_DISTANCE_270;
       }
-    } else if (m_carriage == NoCarriage) {
+    } else if (m_carriage == Carriage_t::NoCarriage) {
       m_carriage = detected_carriage;
     } else if (m_carriage != detected_carriage && m_position > start_position) {
-      m_carriage = Garter;
+      m_carriage = Carriage_t::Garter;
 
       // Belt shift and start position were set when the first magnet passed
       // the sensor and we assumed we were working with a standard carriage.
@@ -222,8 +222,8 @@ void Encoders::encA_falling() {
     // The garter carriage has a second set of magnets that are going to
     // pass the sensor and will reset state incorrectly if allowed to
     // continue.
-    if (hallValueSmall && (m_carriage != Garter)) {
-      m_carriage = Knit;
+    if (hallValueSmall && (m_carriage != Carriage_t::Garter)) {
+      m_carriage = Carriage_t::Knit;
     }
 
     // Belt shift signal only decided in front of hall sensor

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -28,33 +28,33 @@
 
 // Enumerated constants
 
-enum class Direction : int8_t { 
+enum class Direction : signed char { 
   NoDirection = -1, 
   Left = 0, 
   Right = 1
 };
-constexpr int8_t NUM_DIRECTIONS = 2;
+constexpr signed char NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
-enum class Carriage : int8_t {
+enum class Carriage : signed char {
   NoCarriage = -1,
   Knit = 0,
   Lace = 1,
   Garter = 2
 };
-constexpr int8_t NUM_CARRIAGES = 3;
+constexpr signed char NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
-enum class MachineType : int8_t {
+enum class MachineType : signed char {
   NoMachine = -1,
   Kh910 = 0,
   Kh930 = 1,
   Kh270 = 2
 };
-constexpr int8_t NUM_MACHINES = 3;
+constexpr signed char NUM_MACHINES = 3;
 using Machine_t = enum MachineType;
 
-enum class BeltShift : int8_t { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
+enum class BeltShift : signed char { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
 using BeltShift_t = enum BeltShift;
 
 // Machine constants

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -28,7 +28,11 @@
 
 // Enumerated constants
 
-enum Direction { NoDirection = -1, Left = 0, Right = 1, NUM_DIRECTIONS = 2 };
+enum class Direction { 
+  NoDirection = -1, 
+  Left = 0, 
+  Right = 1}
+constexpr uint8_t NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
 enum class Carriage {

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -29,7 +29,7 @@
 // Enumerated constants
 
 enum class Direction : unsigned char { 
-  NoDirection = -1, 
+  NoDirection = 0xFF, 
   Left = 0, 
   Right = 1
 };
@@ -37,7 +37,7 @@ constexpr int NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
 enum class Carriage : unsigned char {
-  NoCarriage = -1,
+  NoCarriage = 0xFF,
   Knit = 0,
   Lace = 1,
   Garter = 2
@@ -46,7 +46,7 @@ constexpr int NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
 enum class MachineType : unsigned char {
-  NoMachine = -1,
+  NoMachine = 0xFF,
   Kh910 = 0,
   Kh930 = 1,
   Kh270 = 2

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -28,7 +28,7 @@
 
 // Enumerated constants
 
-enum class : int8_t Direction { 
+enum class Direction : int8_t { 
   NoDirection = -1, 
   Left = 0, 
   Right = 1
@@ -36,7 +36,7 @@ enum class : int8_t Direction {
 constexpr int8_t NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
-enum class : int8_t Carriage {
+enum class Carriage : int8_t {
   NoCarriage = -1,
   Knit = 0,
   Lace = 1,
@@ -45,7 +45,7 @@ enum class : int8_t Carriage {
 constexpr int8_t NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
-enum class : int8_t MachineType {
+enum class MachineType : int8_t {
   NoMachine = -1,
   Kh910 = 0,
   Kh930 = 1,
@@ -54,7 +54,7 @@ enum class : int8_t MachineType {
 constexpr int8_t NUM_MACHINES = 3;
 using Machine_t = enum MachineType;
 
-enum class : int8_t BeltShift { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
+enum class BeltShift : int8_t { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
 using BeltShift_t = enum BeltShift;
 
 // Machine constants

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -28,33 +28,33 @@
 
 // Enumerated constants
 
-enum class Direction : signed char { 
+enum class Direction : unsigned char { 
   NoDirection = -1, 
   Left = 0, 
   Right = 1
 };
-constexpr signed char NUM_DIRECTIONS = 2;
+constexpr int NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
-enum class Carriage : signed char {
+enum class Carriage : unsigned char {
   NoCarriage = -1,
   Knit = 0,
   Lace = 1,
   Garter = 2
 };
-constexpr signed char NUM_CARRIAGES = 3;
+constexpr int NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
-enum class MachineType : signed char {
+enum class MachineType : unsigned char {
   NoMachine = -1,
   Kh910 = 0,
   Kh930 = 1,
   Kh270 = 2
 };
-constexpr signed char NUM_MACHINES = 3;
+constexpr int NUM_MACHINES = 3;
 using Machine_t = enum MachineType;
 
-enum class BeltShift : signed char { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
+enum class BeltShift : unsigned char { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
 using BeltShift_t = enum BeltShift;
 
 // Machine constants

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -31,7 +31,8 @@
 enum class Direction { 
   NoDirection = -1, 
   Left = 0, 
-  Right = 1}
+  Right = 1
+};
 constexpr uint8_t NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -28,33 +28,33 @@
 
 // Enumerated constants
 
-enum class Direction { 
+enum class : int8_t Direction { 
   NoDirection = -1, 
   Left = 0, 
   Right = 1
 };
-constexpr uint8_t NUM_DIRECTIONS = 2;
+constexpr int8_t NUM_DIRECTIONS = 2;
 using Direction_t = enum Direction;
 
-enum class Carriage {
+enum class : int8_t Carriage {
   NoCarriage = -1,
   Knit = 0,
   Lace = 1,
   Garter = 2
 };
-constexpr uint8_t NUM_CARRIAGES = 3;
+constexpr int8_t NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
-enum class MachineType {
+enum class : int8_t MachineType {
   NoMachine = -1,
   Kh910 = 0,
   Kh930 = 1,
   Kh270 = 2
 };
-constexpr uint8_t NUM_MACHINES = 3;
+constexpr int8_t NUM_MACHINES = 3;
 using Machine_t = enum MachineType;
 
-enum class BeltShift { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
+enum class : int8_t BeltShift { Unknown, Regular, Shifted, Lace_Regular, Lace_Shifted };
 using BeltShift_t = enum BeltShift;
 
 // Machine constants

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -31,13 +31,13 @@
 enum Direction { NoDirection = -1, Left = 0, Right = 1, NUM_DIRECTIONS = 2 };
 using Direction_t = enum Direction;
 
-enum Carriage {
+enum class Carriage {
   NoCarriage = -1,
   Knit = 0,
   Lace = 1,
-  Garter = 2,
-  NUM_CARRIAGES = 3
+  Garter = 2
 };
+constexpr uint8_t NUM_CARRIAGES = 3;
 using Carriage_t = enum Carriage;
 
 enum class MachineType {

--- a/src/ayab/fsm.h
+++ b/src/ayab/fsm.h
@@ -25,12 +25,12 @@
 #define FSM_H_
 
 enum class OpState : unsigned char {
-  wait_for_machine = 1,
-  init = 2,
-  ready = 3,
-  knit = 4,
-  test = 5,
-  error = 6
+  wait_for_machine,
+  init,
+  ready,
+  knit,
+  test,
+  error
 };
 using OpState_t = enum OpState;
 

--- a/src/ayab/fsm.h
+++ b/src/ayab/fsm.h
@@ -24,7 +24,14 @@
 #ifndef FSM_H_
 #define FSM_H_
 
-enum class OpState : uint8_t {wait_for_machine, init, ready, knit, test, error};
+enum class OpState : uint8_t {
+  wait_for_machine = 1,
+  init = 2,
+  ready = 3,
+  knit = 4,
+  test = 5,
+  error = 6
+};
 using OpState_t = enum OpState;
 
 // As of APIv6, the only important distinction

--- a/src/ayab/fsm.h
+++ b/src/ayab/fsm.h
@@ -24,7 +24,7 @@
 #ifndef FSM_H_
 #define FSM_H_
 
-enum class OpState : uint8_t {
+enum class OpState : unsigned char {
   wait_for_machine = 1,
   init = 2,
   ready = 3,
@@ -40,7 +40,7 @@ using OpState_t = enum OpState;
 // diagnostic purposes (that is, for debugging).
 // Non-zero error codes are subject to change.
 // Such changes will be considered non-breaking.
-enum class ErrorCode : uint8_t {
+enum class ErrorCode : unsigned char {
   SUCCESS = 0x00,
 
   // message not understood

--- a/src/ayab/fsm.h
+++ b/src/ayab/fsm.h
@@ -24,7 +24,7 @@
 #ifndef FSM_H_
 #define FSM_H_
 
-enum class OpState {wait_for_machine, init, ready, knit, test, error};
+enum class OpState : uint8_t {wait_for_machine, init, ready, knit, test, error};
 using OpState_t = enum OpState;
 
 // As of APIv6, the only important distinction
@@ -33,7 +33,7 @@ using OpState_t = enum OpState;
 // diagnostic purposes (that is, for debugging).
 // Non-zero error codes are subject to change.
 // Such changes will be considered non-breaking.
-enum class ErrorCode {
+enum class ErrorCode : uint8_t {
   SUCCESS = 0x00,
 
   // message not understood

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -74,9 +74,9 @@ void Knitter::init() {
   m_sOldPosition = 0U;
   m_firstRun = true;
   m_workedOnLine = false;
-  m_lastHall = NoDirection;
+  m_lastHall = Direction_t::NoDirection;
   m_position = 0U;
-  m_hallActive = NoDirection;
+  m_hallActive = Direction_t::NoDirection;
   m_pixelToSet = 0;
 #ifdef DBG_NOMACHINE
   m_prevState = false;
@@ -208,13 +208,13 @@ bool Knitter::isReady() {
   // will be a second magnet passing the sensor.
   // Keep track of the last seen hall sensor because we may be making a decision
   // after it passes.
-  if (m_hallActive != NoDirection) {
+  if (m_hallActive != Direction_t::NoDirection) {
     m_lastHall = m_hallActive;
   }
 
-  bool passedLeft = (Right == m_direction) && (Left == m_lastHall) &&
+  bool passedLeft = (Direction_t::Right == m_direction) && (Direction_t::Left == m_lastHall) &&
         (m_position > (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)] + GARTER_SLOP));
-  bool passedRight = (Left == m_direction) && (Right == m_lastHall) &&
+  bool passedRight = (Direction_t::Left == m_direction) && (Direction_t::Right == m_lastHall) &&
         (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)] - GARTER_SLOP));
   // Machine is initialized when left Hall sensor is passed in Right direction
   // New feature (August 2020): the machine is also initialized
@@ -327,12 +327,12 @@ Machine_t Knitter::getMachineType() {
  * \return Start offset, or 0 if unobtainable.
  */
 uint8_t Knitter::getStartOffset(const Direction_t direction) {
-  if ((direction == NoDirection) || (direction >= NUM_DIRECTIONS) ||
+  if ((direction == Direction_t::NoDirection) ||
       (m_carriage == Carriage_t::NoCarriage) ||
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[static_cast<uint8_t>(m_machineType)][direction][static_cast<uint8_t>(m_carriage)];
+  return START_OFFSET[static_cast<uint8_t>(m_machineType)][static_cast<uint8_t>(direction)][static_cast<uint8_t>(m_carriage)];
 }
 
 /*!
@@ -397,7 +397,7 @@ bool Knitter::calculatePixelAndSolenoid() {
   // calculate the solenoid and pixel to be set
   // implemented according to machine manual
   // magic numbers from machine manual
-  case Right:
+  case Direction_t::Right:
     startOffset = getStartOffset(Left);
     if (m_position >= startOffset) {
       m_pixelToSet = m_position - startOffset;
@@ -415,7 +415,7 @@ bool Knitter::calculatePixelAndSolenoid() {
     }
     break;
 
-  case Left:
+  case Direction_t::Left:
     startOffset = getStartOffset(Right);
     if (m_position <= (END_RIGHT[static_cast<uint8_t>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -154,7 +154,7 @@ Err_t Knitter::startKnitting(uint8_t startNeedle,
   if (pattern_start == nullptr) {
     return ErrorCode::ERR_NULL_POINTER_ARGUMENT;
   }
-  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<signed char>(m_machineType)])) {
+  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<uint8_t>(m_machineType)])) {
     return ErrorCode::ERR_NEEDLE_VALUE_INVALID;
   }
 
@@ -213,9 +213,9 @@ bool Knitter::isReady() {
   }
 
   bool passedLeft = (Direction_t::Right == m_direction) && (Direction_t::Left == m_lastHall) &&
-        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<signed char>(m_machineType)] + GARTER_SLOP));
+        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)] + GARTER_SLOP));
   bool passedRight = (Direction_t::Left == m_direction) && (Direction_t::Right == m_lastHall) &&
-        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(m_machineType)] - GARTER_SLOP));
+        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)] - GARTER_SLOP));
   // Machine is initialized when left Hall sensor is passed in Right direction
   // New feature (August 2020): the machine is also initialized
   // when the right Hall sensor is passed in Left direction.
@@ -288,8 +288,8 @@ void Knitter::knit() {
     m_workedOnLine = true;
   }
 
-  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<signed char>(m_machineType)]) ||
-       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<signed char>(m_machineType)])) &&
+  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<uint8_t>(m_machineType)]) ||
+       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(m_machineType)])) &&
       m_workedOnLine) {
     // outside of the active needles and
     // already worked on the current line -> finished the line
@@ -332,7 +332,7 @@ uint8_t Knitter::getStartOffset(const Direction_t direction) {
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[static_cast<signed char>(m_machineType)][static_cast<signed char>(direction)][static_cast<signed char>(m_carriage)];
+  return START_OFFSET[static_cast<uint8_t>(m_machineType)][static_cast<uint8_t>(direction)][static_cast<uint8_t>(m_carriage)];
 }
 
 /*!
@@ -403,12 +403,12 @@ bool Knitter::calculatePixelAndSolenoid() {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)]) % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
     } else {
       return false;
@@ -417,16 +417,16 @@ bool Knitter::calculatePixelAndSolenoid() {
 
   case Direction_t::Left:
     startOffset = getStartOffset(Direction_t::Right);
-    if (m_position <= (END_RIGHT[static_cast<signed char>(m_machineType)] - startOffset)) {
+    if (m_position <= (END_RIGHT[static_cast<uint8_t>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)]) % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
+        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
     } else {
       return false;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -328,7 +328,7 @@ Machine_t Knitter::getMachineType() {
  */
 uint8_t Knitter::getStartOffset(const Direction_t direction) {
   if ((direction == NoDirection) || (direction >= NUM_DIRECTIONS) ||
-      (m_carriage == Carriage_t::NoCarriage)
+      (m_carriage == Carriage_t::NoCarriage) ||
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -154,7 +154,7 @@ Err_t Knitter::startKnitting(uint8_t startNeedle,
   if (pattern_start == nullptr) {
     return ErrorCode::ERR_NULL_POINTER_ARGUMENT;
   }
-  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<uint8_t>(m_machineType)])) {
+  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<int8_t>(m_machineType)])) {
     return ErrorCode::ERR_NEEDLE_VALUE_INVALID;
   }
 
@@ -213,9 +213,9 @@ bool Knitter::isReady() {
   }
 
   bool passedLeft = (Direction_t::Right == m_direction) && (Direction_t::Left == m_lastHall) &&
-        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)] + GARTER_SLOP));
+        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(m_machineType)] + GARTER_SLOP));
   bool passedRight = (Direction_t::Left == m_direction) && (Direction_t::Right == m_lastHall) &&
-        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)] - GARTER_SLOP));
+        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(m_machineType)] - GARTER_SLOP));
   // Machine is initialized when left Hall sensor is passed in Right direction
   // New feature (August 2020): the machine is also initialized
   // when the right Hall sensor is passed in Left direction.
@@ -288,8 +288,8 @@ void Knitter::knit() {
     m_workedOnLine = true;
   }
 
-  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<uint8_t>(m_machineType)]) ||
-       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(m_machineType)])) &&
+  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<int8_t>(m_machineType)]) ||
+       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<int8_t>(m_machineType)])) &&
       m_workedOnLine) {
     // outside of the active needles and
     // already worked on the current line -> finished the line
@@ -332,7 +332,7 @@ uint8_t Knitter::getStartOffset(const Direction_t direction) {
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[static_cast<uint8_t>(m_machineType)][static_cast<uint8_t>(direction)][static_cast<uint8_t>(m_carriage)];
+  return START_OFFSET[static_cast<int8_t>(m_machineType)][static_cast<int8_t>(direction)][static_cast<int8_t>(m_carriage)];
 }
 
 /*!
@@ -403,12 +403,12 @@ bool Knitter::calculatePixelAndSolenoid() {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       }
     } else {
       return false;
@@ -417,16 +417,16 @@ bool Knitter::calculatePixelAndSolenoid() {
 
   case Direction_t::Left:
     startOffset = getStartOffset(Direction_t::Right);
-    if (m_position <= (END_RIGHT[static_cast<uint8_t>(m_machineType)] - startOffset)) {
+    if (m_position <= (END_RIGHT[static_cast<int8_t>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
       }
     } else {
       return false;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -332,7 +332,7 @@ uint8_t Knitter::getStartOffset(const Direction_t direction) {
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[m_machineType][direction][m_carriage];
+  return START_OFFSET[static_cast<uint8_t>(m_machineType)][direction][m_carriage];
 }
 
 /*!
@@ -420,7 +420,7 @@ bool Knitter::calculatePixelAndSolenoid() {
     if (m_position <= (END_RIGHT[static_cast<uint8_t>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 
-      if ((BeltShift::Regular == m_beltShift) || (m_machineType == Kh270)) {
+      if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
         m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
         m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -425,7 +425,7 @@ bool Knitter::calculatePixelAndSolenoid() {
       } else if (BeltShift::Shifted == m_beltShift) {
         m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
-      if (Lace == m_carriage) {
+      if (Carriage_t::Lace == m_carriage) {
         m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
     } else {

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -328,11 +328,11 @@ Machine_t Knitter::getMachineType() {
  */
 uint8_t Knitter::getStartOffset(const Direction_t direction) {
   if ((direction == NoDirection) || (direction >= NUM_DIRECTIONS) ||
-      (m_carriage == NoCarriage) || (m_carriage >= NUM_CARRIAGES) ||
+      (m_carriage == Carriage_t::NoCarriage)
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[static_cast<uint8_t>(m_machineType)][direction][m_carriage];
+  return START_OFFSET[static_cast<uint8_t>(m_machineType)][direction][static_cast<uint8_t>(m_carriage)];
 }
 
 /*!
@@ -407,7 +407,7 @@ bool Knitter::calculatePixelAndSolenoid() {
       } else if (BeltShift::Shifted == m_beltShift) {
         m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
-      if (Lace == m_carriage) {
+      if (Carriage_t::Lace == m_carriage) {
         m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
       }
     } else {

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -154,7 +154,7 @@ Err_t Knitter::startKnitting(uint8_t startNeedle,
   if (pattern_start == nullptr) {
     return ErrorCode::ERR_NULL_POINTER_ARGUMENT;
   }
-  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<int8_t>(m_machineType)])) {
+  if ((startNeedle >= stopNeedle) || (stopNeedle >= NUM_NEEDLES[static_cast<signed char>(m_machineType)])) {
     return ErrorCode::ERR_NEEDLE_VALUE_INVALID;
   }
 
@@ -213,9 +213,9 @@ bool Knitter::isReady() {
   }
 
   bool passedLeft = (Direction_t::Right == m_direction) && (Direction_t::Left == m_lastHall) &&
-        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(m_machineType)] + GARTER_SLOP));
+        (m_position > (END_LEFT_PLUS_OFFSET[static_cast<signed char>(m_machineType)] + GARTER_SLOP));
   bool passedRight = (Direction_t::Left == m_direction) && (Direction_t::Right == m_lastHall) &&
-        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(m_machineType)] - GARTER_SLOP));
+        (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(m_machineType)] - GARTER_SLOP));
   // Machine is initialized when left Hall sensor is passed in Right direction
   // New feature (August 2020): the machine is also initialized
   // when the right Hall sensor is passed in Left direction.
@@ -288,8 +288,8 @@ void Knitter::knit() {
     m_workedOnLine = true;
   }
 
-  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<int8_t>(m_machineType)]) ||
-       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<int8_t>(m_machineType)])) &&
+  if (((m_pixelToSet < m_startNeedle - END_OF_LINE_OFFSET_L[static_cast<signed char>(m_machineType)]) ||
+       (m_pixelToSet > m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<signed char>(m_machineType)])) &&
       m_workedOnLine) {
     // outside of the active needles and
     // already worked on the current line -> finished the line
@@ -332,7 +332,7 @@ uint8_t Knitter::getStartOffset(const Direction_t direction) {
       (m_machineType == Machine_t::NoMachine)) {
     return 0U;
   }
-  return START_OFFSET[static_cast<int8_t>(m_machineType)][static_cast<int8_t>(direction)][static_cast<int8_t>(m_carriage)];
+  return START_OFFSET[static_cast<signed char>(m_machineType)][static_cast<signed char>(direction)][static_cast<signed char>(m_carriage)];
 }
 
 /*!
@@ -403,12 +403,12 @@ bool Knitter::calculatePixelAndSolenoid() {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_solenoidToSet = (m_position - HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)]) % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_pixelToSet = m_pixelToSet + HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       }
     } else {
       return false;
@@ -417,16 +417,16 @@ bool Knitter::calculatePixelAndSolenoid() {
 
   case Direction_t::Left:
     startOffset = getStartOffset(Direction_t::Right);
-    if (m_position <= (END_RIGHT[static_cast<int8_t>(m_machineType)] - startOffset)) {
+    if (m_position <= (END_RIGHT[static_cast<signed char>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
-        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)]) % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_solenoidToSet = (m_position + HALF_SOLENOIDS_NUM[static_cast<signed char>(m_machineType)]) % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       } else if (BeltShift::Shifted == m_beltShift) {
-        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_solenoidToSet = m_position % SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       }
       if (Carriage_t::Lace == m_carriage) {
-        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<int8_t>(m_machineType)];
+        m_pixelToSet = m_pixelToSet - SOLENOIDS_NUM[static_cast<signed char>(m_machineType)];
       }
     } else {
       return false;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -398,7 +398,7 @@ bool Knitter::calculatePixelAndSolenoid() {
   // implemented according to machine manual
   // magic numbers from machine manual
   case Direction_t::Right:
-    startOffset = getStartOffset(Left);
+    startOffset = getStartOffset(Direction_t::Left);
     if (m_position >= startOffset) {
       m_pixelToSet = m_position - startOffset;
 
@@ -416,7 +416,7 @@ bool Knitter::calculatePixelAndSolenoid() {
     break;
 
   case Direction_t::Left:
-    startOffset = getStartOffset(Right);
+    startOffset = getStartOffset(Direction_t::Right);
     if (m_position <= (END_RIGHT[static_cast<uint8_t>(m_machineType)] - startOffset)) {
       m_pixelToSet = m_position - startOffset;
 

--- a/src/ayab/main.cpp
+++ b/src/ayab/main.cpp
@@ -35,25 +35,25 @@
 // Global definitions: references elsewhere must use `extern`.
 // Each of the following is a pointer to a singleton class
 // containing static methods.
-constexpr GlobalBeeper *beeper;
-constexpr GlobalCom *com;
-constexpr GlobalEncoders *encoders;
-constexpr GlobalFsm *fsm;
-constexpr GlobalKnitter *knitter;
-constexpr GlobalSolenoids *solenoids;
-constexpr GlobalTester *tester;
+constexpr GlobalBeeper    *beeper    = GlobalBeeper();
+constexpr GlobalCom       *com       = GlobalCom();
+constexpr GlobalEncoders  *encoders  = GlobalEncoders();
+constexpr GlobalFsm       *fsm       = GlobalFsm();
+constexpr GlobalKnitter   *knitter   = GlobalKnitter();
+constexpr GlobalSolenoids *solenoids = GlobalSolenoids();
+constexpr GlobalTester    *tester    = GlobalTester();
 
 // Initialize static members.
 // Each singleton class contains a pointer to a static instance
 // that implements a public interface. When testing, a pointer
 // to an instance of a mock class can be substituted.
-BeeperInterface *GlobalBeeper::m_instance = new Beeper();
-ComInterface *GlobalCom::m_instance = new Com();
-EncodersInterface *GlobalEncoders::m_instance = new Encoders();
-FsmInterface *GlobalFsm::m_instance = new Fsm();
-KnitterInterface *GlobalKnitter::m_instance = new Knitter();
+BeeperInterface    *GlobalBeeper::m_instance    = new Beeper();
+ComInterface       *GlobalCom::m_instance       = new Com();
+EncodersInterface  *GlobalEncoders::m_instance  = new Encoders();
+FsmInterface       *GlobalFsm::m_instance       = new Fsm();
+KnitterInterface   *GlobalKnitter::m_instance   = new Knitter();
 SolenoidsInterface *GlobalSolenoids::m_instance = new Solenoids();
-TesterInterface *GlobalTester::m_instance = new Tester();
+TesterInterface    *GlobalTester::m_instance    = new Tester();
 
 /*!
  * Setup - do once before going to the main loop.

--- a/src/ayab/main.cpp
+++ b/src/ayab/main.cpp
@@ -35,13 +35,13 @@
 // Global definitions: references elsewhere must use `extern`.
 // Each of the following is a pointer to a singleton class
 // containing static methods.
-constexpr GlobalBeeper    *beeper    = GlobalBeeper();
-constexpr GlobalCom       *com       = GlobalCom();
-constexpr GlobalEncoders  *encoders  = GlobalEncoders();
-constexpr GlobalFsm       *fsm       = GlobalFsm();
-constexpr GlobalKnitter   *knitter   = GlobalKnitter();
-constexpr GlobalSolenoids *solenoids = GlobalSolenoids();
-constexpr GlobalTester    *tester    = GlobalTester();
+constexpr GlobalBeeper    *beeper;
+constexpr GlobalCom       *com;
+constexpr GlobalEncoders  *encoders;
+constexpr GlobalFsm       *fsm;
+constexpr GlobalKnitter   *knitter;
+constexpr GlobalSolenoids *solenoids;
+constexpr GlobalTester    *tester;
 
 // Initialize static members.
 // Each singleton class contains a pointer to a static instance

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -91,7 +91,7 @@ protected:
   }
 
   void reqInit(Machine_t machine) {
-    uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(machine)};
+    uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(machine)};
     EXPECT_CALL(*fsmMock, setState(OpState::init));
     expected_write_onPacketReceived(buffer, sizeof(buffer), true);
   }
@@ -104,7 +104,7 @@ TEST_F(ComTest, test_API) {
 */
 
 TEST_F(ComTest, test_reqInit_too_short_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(Machine_t::Kh910)};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910)};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(EXPECTED_LONGER_MESSAGE));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -116,7 +116,7 @@ TEST_F(ComTest, test_reqInit_too_short_error) {
 }
 
 TEST_F(ComTest, test_reqInit_checksum_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(Machine_t::Kh910), 0};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910), 0};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(CHECKSUM_ERROR));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -138,7 +138,7 @@ TEST_F(ComTest, test_reqtest_fail) {
 }
 
 TEST_F(ComTest, test_reqtest_success_KH270) {
-  uint8_t buffer[] = {reqTest_msgid, static_cast<signed char>(Machine_t::Kh270)};
+  uint8_t buffer[] = {reqTest_msgid, static_cast<uint8_t>(Machine_t::Kh270)};
   EXPECT_CALL(*fsmMock, setState(OpState::test));
   EXPECT_CALL(*knitterMock, setMachineType(Machine_t::Kh270));
   EXPECT_CALL(*arduinoMock, millis);

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -91,7 +91,7 @@ protected:
   }
 
   void reqInit(Machine_t machine) {
-    uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(machine)};
+    uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(machine)};
     EXPECT_CALL(*fsmMock, setState(OpState::init));
     expected_write_onPacketReceived(buffer, sizeof(buffer), true);
   }
@@ -104,7 +104,7 @@ TEST_F(ComTest, test_API) {
 */
 
 TEST_F(ComTest, test_reqInit_too_short_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910)};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(Machine_t::Kh910)};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(EXPECTED_LONGER_MESSAGE));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -116,7 +116,7 @@ TEST_F(ComTest, test_reqInit_too_short_error) {
 }
 
 TEST_F(ComTest, test_reqInit_checksum_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910), 0};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(Machine_t::Kh910), 0};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(CHECKSUM_ERROR));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -138,7 +138,7 @@ TEST_F(ComTest, test_reqtest_fail) {
 }
 
 TEST_F(ComTest, test_reqtest_success_KH270) {
-  uint8_t buffer[] = {reqTest_msgid, static_cast<uint8_t>(Machine_t::Kh270)};
+  uint8_t buffer[] = {reqTest_msgid, static_cast<int8_t>(Machine_t::Kh270)};
   EXPECT_CALL(*fsmMock, setState(OpState::test));
   EXPECT_CALL(*knitterMock, setMachineType(Machine_t::Kh270));
   EXPECT_CALL(*arduinoMock, millis);

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -91,7 +91,7 @@ protected:
   }
 
   void reqInit(Machine_t machine) {
-    uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(machine)};
+    uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(machine)};
     EXPECT_CALL(*fsmMock, setState(OpState::init));
     expected_write_onPacketReceived(buffer, sizeof(buffer), true);
   }
@@ -104,7 +104,7 @@ TEST_F(ComTest, test_API) {
 */
 
 TEST_F(ComTest, test_reqInit_too_short_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(Machine_t::Kh910)};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(Machine_t::Kh910)};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(EXPECTED_LONGER_MESSAGE));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -116,7 +116,7 @@ TEST_F(ComTest, test_reqInit_too_short_error) {
 }
 
 TEST_F(ComTest, test_reqInit_checksum_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<int8_t>(Machine_t::Kh910), 0};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<signed char>(Machine_t::Kh910), 0};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(CHECKSUM_ERROR));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -138,7 +138,7 @@ TEST_F(ComTest, test_reqtest_fail) {
 }
 
 TEST_F(ComTest, test_reqtest_success_KH270) {
-  uint8_t buffer[] = {reqTest_msgid, static_cast<int8_t>(Machine_t::Kh270)};
+  uint8_t buffer[] = {reqTest_msgid, static_cast<signed char>(Machine_t::Kh270)};
   EXPECT_CALL(*fsmMock, setState(OpState::test));
   EXPECT_CALL(*knitterMock, setMachineType(Machine_t::Kh270));
   EXPECT_CALL(*arduinoMock, millis);

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -392,5 +392,5 @@ TEST_F(ComTest, test_send_indState) {
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R));
   expect_write(true);
-  com->send_indState(Knit, 0, ErrorCode::SUCCESS);
+  com->send_indState(Carriage::Knit, 0, ErrorCode::SUCCESS);
 }

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -180,7 +180,7 @@ TEST_F(ComTest, test_reqstart_success_KH910) {
 }
 
 TEST_F(ComTest, test_reqstart_success_KH270) {
-  reqInit(Machine_t::h270);
+  reqInit(Machine_t::Kh270);
   uint8_t buffer[] = {reqStart_msgid, 0, 10, 1, 0x36};
   EXPECT_CALL(*knitterMock, startKnitting);
   expected_write_onPacketReceived(buffer, sizeof(buffer), false);

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -104,7 +104,7 @@ TEST_F(ComTest, test_API) {
 */
 
 TEST_F(ComTest, test_reqInit_too_short_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Kh910)};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910)};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(EXPECTED_LONGER_MESSAGE));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -116,7 +116,7 @@ TEST_F(ComTest, test_reqInit_too_short_error) {
 }
 
 TEST_F(ComTest, test_reqInit_checksum_error) {
-  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Kh910), 0};
+  uint8_t buffer[] = {reqInit_msgid, static_cast<uint8_t>(Machine_t::Kh910), 0};
   //EXPECT_CALL(*serialMock, write(cnfInit_msgid));
   //EXPECT_CALL(*serialMock, write(CHECKSUM_ERROR));
   //EXPECT_CALL(*serialMock, write(SLIP::END));
@@ -138,7 +138,7 @@ TEST_F(ComTest, test_reqtest_fail) {
 }
 
 TEST_F(ComTest, test_reqtest_success_KH270) {
-  uint8_t buffer[] = {reqTest_msgid, Kh270};
+  uint8_t buffer[] = {reqTest_msgid, static_cast<uint8_t>(Machine_t::Kh270)};
   EXPECT_CALL(*fsmMock, setState(OpState::test));
   EXPECT_CALL(*knitterMock, setMachineType(Kh270));
   EXPECT_CALL(*arduinoMock, millis);
@@ -170,7 +170,7 @@ TEST_F(ComTest, test_reqstart_fail2) {
 }
 
 TEST_F(ComTest, test_reqstart_success_KH910) {
-  reqInit(Kh910);
+  reqInit(Machine_t::Kh910);
   uint8_t buffer[] = {reqStart_msgid, 0, 10, 1, 0x36};
   EXPECT_CALL(*knitterMock, startKnitting);
   expected_write_onPacketReceived(buffer, sizeof(buffer), false);
@@ -180,7 +180,7 @@ TEST_F(ComTest, test_reqstart_success_KH910) {
 }
 
 TEST_F(ComTest, test_reqstart_success_KH270) {
-  reqInit(Kh270);
+  reqInit(Machine_t::h270);
   uint8_t buffer[] = {reqStart_msgid, 0, 10, 1, 0x36};
   EXPECT_CALL(*knitterMock, startKnitting);
   expected_write_onPacketReceived(buffer, sizeof(buffer), false);
@@ -304,7 +304,7 @@ TEST_F(ComTest, test_cnfline_kh910) {
                         0xA7}; // CRC8
 
   // start KH910 job
-  knitterMock->initMachine(Kh910);
+  knitterMock->initMachine(Machine_t::Kh910);
   knitterMock->startKnitting(0, 199, pattern, false);
 
   // first call increments line number to zero, not accepted

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -140,7 +140,7 @@ TEST_F(ComTest, test_reqtest_fail) {
 TEST_F(ComTest, test_reqtest_success_KH270) {
   uint8_t buffer[] = {reqTest_msgid, static_cast<uint8_t>(Machine_t::Kh270)};
   EXPECT_CALL(*fsmMock, setState(OpState::test));
-  EXPECT_CALL(*knitterMock, setMachineType(Kh270));
+  EXPECT_CALL(*knitterMock, setMachineType(Machine_t::Kh270));
   EXPECT_CALL(*arduinoMock, millis);
   expected_write_onPacketReceived(buffer, sizeof(buffer), false);
 

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -342,7 +342,7 @@ TEST_F(EncodersTest, test_init) {
 }
 
 TEST_F(EncodersTest, test_getHallValue) {
-  uint16_t v = encoders->getHallValue(NoDirection);
+  uint16_t v = encoders->getHallValue(Direction_t::NoDirection);
   ASSERT_EQ(v, 0u);
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L));
   v = encoders->getHallValue(Direction_t::Left);

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -34,7 +34,7 @@ class EncodersTest : public ::testing::Test {
 protected:
   void SetUp() override {
     arduinoMock = arduinoMockInstance();
-    encoders->init(Kh910);
+    encoders->init(Machine_t::Kh910);
   }
 
   void TearDown() override {
@@ -66,7 +66,7 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
-  ASSERT_FALSE(encoders->getMachineType() == Kh270);
+  ASSERT_FALSE(encoders->getMachineType() == Machine_t::Kh270);
   ASSERT_EQ(encoders->getCarriage(), NoCarriage);
   // We should not enter the falling function
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
@@ -98,7 +98,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 
 TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
   encoders->init(Kh270);
-  ASSERT_TRUE(encoders->getMachineType() == Kh270);
+  ASSERT_TRUE(encoders->getMachineType() == Machine_t::Kh270);
   // We should not enter the falling function
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
   // Create a rising edge
@@ -266,7 +266,7 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
 
 // requires FILTER_R_MIN != 0
 TEST_F(EncodersTest, test_encA_falling_set_K_carriage_KH910) {
-  ASSERT_TRUE(encoders->getMachineType() == Kh910);
+  ASSERT_TRUE(encoders->getMachineType() == Machine_t::Kh910);
 
   // Create a rising edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
@@ -332,13 +332,13 @@ TEST_F(EncodersTest, test_getCarriage) {
 
 TEST_F(EncodersTest, test_getMachineType) {
   Machine_t m = encoders->getMachineType();
-  ASSERT_EQ(m, Kh910);
+  ASSERT_EQ(m, Machine_t::Kh910);
 }
 
 TEST_F(EncodersTest, test_init) {
-  encoders->init(Kh270);
+  encoders->init(Machine_t::Kh270);
   Machine_t m = encoders->getMachineType();
-  ASSERT_EQ(m, Kh270);
+  ASSERT_EQ(m, Machine_t::Kh270);
 }
 
 TEST_F(EncodersTest, test_getHallValue) {

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -60,7 +60,7 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
       .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
-  ASSERT_EQ(encoders->getDirection(), Right);
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getPosition(), 0x01);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
 }
@@ -89,8 +89,8 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getDirection(), Right);
-  ASSERT_EQ(encoders->getHallActive(), Left);
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
+  ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
   ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
@@ -120,8 +120,8 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getDirection(), Right);
-  ASSERT_EQ(encoders->getHallActive(), Left);
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
+  ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
   ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
@@ -208,8 +208,8 @@ TEST_F(EncodersTest, test_encA_falling_in_front) {
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getDirection(), Right);
-  ASSERT_EQ(encoders->getHallActive(), Right);
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
+  ASSERT_EQ(encoders->getHallActive(), Direction_t::Right);
   ASSERT_EQ(encoders->getPosition(), 227);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Shifted);
@@ -317,12 +317,12 @@ TEST_F(EncodersTest, test_getBeltShift) {
 
 TEST_F(EncodersTest, test_getDirection) {
   Direction_t d = encoders->getDirection();
-  ASSERT_EQ(d, NoDirection);
+  ASSERT_EQ(d, Direction_t::NoDirection);
 }
 
 TEST_F(EncodersTest, test_getHallActive) {
   Direction_t d = encoders->getHallActive();
-  ASSERT_EQ(d, NoDirection);
+  ASSERT_EQ(d, Direction_t::NoDirection);
 }
 
 TEST_F(EncodersTest, test_getCarriage) {
@@ -345,12 +345,12 @@ TEST_F(EncodersTest, test_getHallValue) {
   uint16_t v = encoders->getHallValue(NoDirection);
   ASSERT_EQ(v, 0u);
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L));
-  v = encoders->getHallValue(Left);
+  v = encoders->getHallValue(Direction_t::Left);
   ASSERT_EQ(v, 0u);
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R));
-  v = encoders->getHallValue(Right);
+  v = encoders->getHallValue(Direction_t::Right);
   ASSERT_EQ(v, 0u);
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).WillOnce(Return(0xbeefu));
-  v = encoders->getHallValue(Right);
+  v = encoders->getHallValue(Direction_t::Right);
   ASSERT_EQ(v, 0xbeefu);
 }

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -62,12 +62,12 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getPosition(), 0x01);
-  ASSERT_EQ(encoders->getCarriage(), NoCarriage);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
   ASSERT_FALSE(encoders->getMachineType() == Machine_t::Kh270);
-  ASSERT_EQ(encoders->getCarriage(), NoCarriage);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
   // We should not enter the falling function
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
   // Create a rising edge
@@ -92,7 +92,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getHallActive(), Left);
   ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
-  ASSERT_EQ(encoders->getCarriage(), Lace);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
 
@@ -123,7 +123,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getHallActive(), Left);
   ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
-  ASSERT_EQ(encoders->getCarriage(), Knit);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
 
@@ -140,7 +140,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getCarriage(), Knit);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
 
   // Create a falling edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
@@ -158,7 +158,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getCarriage(), Garter);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Garter);
 }
 
 TEST_F(EncodersTest, test_encA_falling_not_in_front) {
@@ -211,7 +211,7 @@ TEST_F(EncodersTest, test_encA_falling_in_front) {
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getHallActive(), Right);
   ASSERT_EQ(encoders->getPosition(), 227);
-  ASSERT_EQ(encoders->getCarriage(), NoCarriage);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Shifted);
 }
 
@@ -283,7 +283,7 @@ TEST_F(EncodersTest, test_encA_falling_set_K_carriage_KH910) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
 
   encoders->encA_interrupt();
-  ASSERT_EQ(encoders->getCarriage(), Knit);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
 }
 
 TEST_F(EncodersTest, test_encA_falling_not_at_end) {
@@ -327,7 +327,7 @@ TEST_F(EncodersTest, test_getHallActive) {
 
 TEST_F(EncodersTest, test_getCarriage) {
   Carriage_t c = encoders->getCarriage();
-  ASSERT_EQ(c, NoCarriage);
+  ASSERT_EQ(c, Carriage_t::NoCarriage);
 }
 
 TEST_F(EncodersTest, test_getMachineType) {

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -58,7 +58,7 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // Not in front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getPosition(), 0x01);
@@ -97,7 +97,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
-  encoders->init(Kh270);
+  encoders->init(Machine_t::Kh270);
   ASSERT_TRUE(encoders->getMachineType() == Machine_t::Kh270);
   // We should not enter the falling function
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -83,7 +83,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -91,7 +91,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getHallActive(), Left);
-  ASSERT_EQ(encoders->getPosition(), END_OFFSET[encoders->getMachineType()]);
+  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Lace);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
@@ -114,7 +114,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -122,7 +122,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
 
   ASSERT_EQ(encoders->getDirection(), Right);
   ASSERT_EQ(encoders->getHallActive(), Left);
-  ASSERT_EQ(encoders->getPosition(), END_OFFSET[encoders->getMachineType()]);
+  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Knit);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
@@ -134,7 +134,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true)).WillOnce(Return(false));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[encoders->getMachineType()] + 1));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -145,7 +145,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   // Create a falling edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
   encoders->encA_interrupt();
   // Create a rising edge
@@ -154,7 +154,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
 
   encoders->encA_interrupt();
 
@@ -173,13 +173,13 @@ TEST_F(EncodersTest, test_encA_falling_not_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true)).WillOnce(Return(false));
   // Not in front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MIN[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_R_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
 
   encoders->encA_interrupt();
 }
@@ -196,13 +196,13 @@ TEST_F(EncodersTest, test_encA_falling_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false)).WillOnce(Return(false));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
   // BeltShift is shifted
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -223,25 +223,25 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).Times(0);
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
 
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 227);
 
   uint16_t pos = 227;
-  while (pos < END_RIGHT[encoders->getMachineType()]) {
+  while (pos < END_RIGHT[static_cast<uint8_t>(encoders->getMachineType())]) {
     // Rising
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
     EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-        .WillOnce(Return(FILTER_L_MAX[encoders->getMachineType()]));
+        .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
     encoders->encA_interrupt();
     ASSERT_EQ(encoders->getPosition(), ++pos);
 
@@ -249,7 +249,7 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
     EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-        .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()]));
+        .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
     encoders->encA_interrupt();
     ASSERT_EQ(encoders->getPosition(), pos);
   }
@@ -259,7 +259,7 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), pos);
 }
@@ -279,7 +279,7 @@ TEST_F(EncodersTest, test_encA_falling_set_K_carriage_KH910) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MIN[encoders->getMachineType()] - 1));
+      .WillOnce(Return(FILTER_R_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
 
   encoders->encA_interrupt();
@@ -292,7 +292,7 @@ TEST_F(EncodersTest, test_encA_falling_not_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 28);
 
@@ -300,7 +300,7 @@ TEST_F(EncodersTest, test_encA_falling_not_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[encoders->getMachineType()]));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 28);
 }

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -58,7 +58,7 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // Not in front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getPosition(), 0x01);
@@ -83,7 +83,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -91,7 +91,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 
   ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
-  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
+  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<int8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
@@ -114,7 +114,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -122,7 +122,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
 
   ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
-  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<uint8_t>(encoders->getMachineType())]);
+  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<int8_t>(encoders->getMachineType())]);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
   ASSERT_EQ(encoders->getBeltShift(), BeltShift::Regular);
 }
@@ -134,7 +134,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true)).WillOnce(Return(false));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -145,7 +145,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   // Create a falling edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
   encoders->encA_interrupt();
   // Create a rising edge
@@ -154,7 +154,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
 
   encoders->encA_interrupt();
 
@@ -173,13 +173,13 @@ TEST_F(EncodersTest, test_encA_falling_not_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true)).WillOnce(Return(false));
   // Not in front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_R_MIN[static_cast<int8_t>(encoders->getMachineType())]));
 
   encoders->encA_interrupt();
 }
@@ -196,13 +196,13 @@ TEST_F(EncodersTest, test_encA_falling_in_front) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false)).WillOnce(Return(false));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
   // BeltShift is shifted
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
@@ -223,25 +223,25 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<int8_t>(encoders->getMachineType())]));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).Times(0);
   encoders->encA_interrupt();
 
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
 
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 227);
 
   uint16_t pos = 227;
-  while (pos < END_RIGHT[static_cast<uint8_t>(encoders->getMachineType())]) {
+  while (pos < END_RIGHT[static_cast<int8_t>(encoders->getMachineType())]) {
     // Rising
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
     EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-        .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
+        .WillOnce(Return(FILTER_L_MAX[static_cast<int8_t>(encoders->getMachineType())]));
     encoders->encA_interrupt();
     ASSERT_EQ(encoders->getPosition(), ++pos);
 
@@ -249,7 +249,7 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
     EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
     EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-        .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
+        .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())]));
     encoders->encA_interrupt();
     ASSERT_EQ(encoders->getPosition(), pos);
   }
@@ -259,7 +259,7 @@ TEST_F(EncodersTest, test_encA_falling_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_L_MAX[static_cast<int8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), pos);
 }
@@ -279,7 +279,7 @@ TEST_F(EncodersTest, test_encA_falling_set_K_carriage_KH910) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MIN[static_cast<uint8_t>(encoders->getMachineType())] - 1));
+      .WillOnce(Return(FILTER_R_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
 
   encoders->encA_interrupt();
@@ -292,7 +292,7 @@ TEST_F(EncodersTest, test_encA_falling_not_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 28);
 
@@ -300,7 +300,7 @@ TEST_F(EncodersTest, test_encA_falling_not_at_end) {
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false));
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<uint8_t>(encoders->getMachineType())]));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())]));
   encoders->encA_interrupt();
   ASSERT_EQ(encoders->getPosition(), 28);
 }

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -86,7 +86,7 @@ protected:
     expect_knitter_init();
     knitter->init();
     knitter->setMachineType(Machine_t::Kh910);
-    expected_isr(NoDirection, NoDirection, 0);
+    expected_isr(Direction_t::NoDirection, Direction_t::NoDirection, 0);
   }
 
   void TearDown() override {
@@ -234,17 +234,17 @@ TEST_F(FsmTest, test_dispatch_init) {
   ASSERT_EQ(fsm->getState(), OpState::init);
 
   // no transition to state `OpState::ready`
-  expected_isr(Left, Left, 0);
+  expected_isr(Direction_t::Left, Direction_t::Left, 0);
   expected_dispatch_init();
   ASSERT_TRUE(fsm->getState() == OpState::init);
 
   // no transition to state `OpState::ready`
-  expected_isr(Right, Right, 0);
+  expected_isr(Direction_t::Right, Direction_t::Right, 0);
   expected_dispatch_init();
   ASSERT_TRUE(fsm->getState() == OpState::init);
 
   // transition to state `OpState::ready`
-  expected_isr(Left, Right, positionPassedRight);
+  expected_isr(Direction_t::Left, Direction_t::Right, positionPassedRight);
   expect_get_ready();
   expected_dispatch();
   ASSERT_EQ(fsm->getState(), OpState::ready);
@@ -254,7 +254,7 @@ TEST_F(FsmTest, test_dispatch_init) {
   expected_dispatch_ready();
 
   // transition to state `OpState::ready`
-  expected_isr(Right, Left, positionPassedLeft);
+  expected_isr(Direction_t::Right, Direction_t::Left, positionPassedLeft);
   expect_get_ready();
   expected_dispatch();
   ASSERT_TRUE(fsm->getState() == OpState::ready);

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -49,8 +49,8 @@ extern SolenoidsMock *solenoids;
 extern TesterMock *tester;
 
 // Defaults for position
-const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
-const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
+const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
+const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
 
 class FsmTest : public ::testing::Test {
 protected:

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -49,8 +49,8 @@ extern SolenoidsMock *solenoids;
 extern TesterMock *tester;
 
 // Defaults for position
-const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<signed char>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
-const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
+const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
+const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
 
 class FsmTest : public ::testing::Test {
 protected:

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -49,8 +49,8 @@ extern SolenoidsMock *solenoids;
 extern TesterMock *tester;
 
 // Defaults for position
-const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
-const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
+const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<signed char>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
+const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
 
 class FsmTest : public ::testing::Test {
 protected:

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -49,8 +49,8 @@ extern SolenoidsMock *solenoids;
 extern TesterMock *tester;
 
 // Defaults for position
-const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[Kh910] + GARTER_SLOP) + 1;
-const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[Kh910] - GARTER_SLOP) - 1;
+const uint8_t positionPassedLeft = (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] + GARTER_SLOP) + 1;
+const uint8_t positionPassedRight = (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(Machine_t::Kh910)] - GARTER_SLOP) - 1;
 
 class FsmTest : public ::testing::Test {
 protected:
@@ -85,7 +85,7 @@ protected:
     // ASSERT_TRUE(fsm->getState() == OpState::init);
     expect_knitter_init();
     knitter->init();
-    knitter->setMachineType(Kh910);
+    knitter->setMachineType(Machine_t::Kh910);
     expected_isr(NoDirection, NoDirection, 0);
   }
 

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -455,12 +455,12 @@ TEST_F(KnitterTest, test_knit_Kh270) {
 
   // don't set `m_workedonline` to `true`
   const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh270)];
-  expected_isr(8 + STOP_NEEDLE + OFFSET, Right, Left, BeltShift::Regular, Knit);
+  expected_isr(8 + STOP_NEEDLE + OFFSET, Right, Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
   expected_dispatch_knit(false);
 
-  expected_isr(START_NEEDLE, Right, Left, BeltShift::Regular, Knit);
+  expected_isr(START_NEEDLE, Right, Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
   expected_dispatch_knit(false);

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -300,7 +300,7 @@ TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_notReady) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[Kh910] - 1, pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -524,7 +524,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 }
 
 TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
-  get_to_knit(Kh910);
+  get_to_knit(Machine_t::Kh910);
 
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
@@ -674,10 +674,8 @@ TEST_F(KnitterTest, test_getStartOffset) {
   ASSERT_EQ(knitter->getStartOffset(Right), 0);
 
   knitter->m_carriage = Lace;
-  knitter->m_machineType = NoMachine;
+  knitter->m_machineType = Machine_t::NoMachine;
   ASSERT_EQ(knitter->getStartOffset(Left), 0);
-
-  knitter->m_machineType = NUM_MACHINES;
   ASSERT_EQ(knitter->getStartOffset(Right), 0);
 
   // test expectations without destroying instance

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -89,11 +89,11 @@ protected:
   TesterMock *testerMock;
 
   uint8_t get_position_past_left() {
-    return (END_LEFT_PLUS_OFFSET[static_cast<signed char>(encoders->getMachineType())] + GARTER_SLOP) + 1;
+    return (END_LEFT_PLUS_OFFSET[static_cast<unit8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
   }
 
   uint8_t get_position_past_right() {
-    return (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(encoders->getMachineType())] - GARTER_SLOP) - 1;
+    return (END_RIGHT_MINUS_OFFSET[static_cast<unit8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
   }
 
   void expect_knitter_init() {
@@ -199,7 +199,7 @@ protected:
     get_to_ready(m);
     uint8_t pattern[] = {1};
     EXPECT_CALL(*beeperMock, ready);
-    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
+    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
     expected_dispatch_ready();
 
     // ends in state `OpState::knit`
@@ -283,7 +283,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   ASSERT_EQ(m, Machine_t::NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
-      knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
+      knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -300,7 +300,7 @@ TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_notReady) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1, pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1, pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -335,11 +335,11 @@ TEST_F(KnitterTest, test_startKnitting_failures) {
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
 
   // `m_stopNeedle` out of range
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)], pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)], pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // null pattern
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1, nullptr,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1, nullptr,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -355,7 +355,7 @@ TEST_F(KnitterTest, test_setNextLine) {
   expected_dispatch_knit(true);
 
   // outside of the active needles
-  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(1);
   expected_dispatch_knit(false);
 
@@ -386,8 +386,8 @@ TEST_F(KnitterTest, test_knit_Kh910) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW)); // green LED off
   expected_dispatch();
@@ -404,7 +404,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)];
   expected_isr(8 + STOP_NEEDLE + OFFSET);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -430,8 +430,8 @@ TEST_F(KnitterTest, test_knit_Kh270) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh270)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh270)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh270)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh270)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW));
   expected_dispatch();
@@ -454,7 +454,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh270)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh270)];
   expected_isr(8 + STOP_NEEDLE + OFFSET, Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -478,7 +478,7 @@ TEST_F(KnitterTest, test_knit_line_request) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is set above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1);
+  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1);
 
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expected_dispatch_knit(false);
@@ -505,7 +505,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // `m_lastLineFlag` is `true`
   knitter->setLastLine();
@@ -529,7 +529,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
   uint8_t wanted_pixel =
-      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1;
+      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1;
   knitter->m_firstRun = false;
   knitter->m_direction = Direction_t::Left;
   knitter->m_position = wanted_pixel + knitter->getStartOffset(Direction_t::Right);
@@ -581,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);
@@ -635,7 +635,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[static_cast<signed char>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
+  expected_isr(END_RIGHT[static_cast<unit8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
@@ -650,7 +650,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[static_cast<signed char>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
+  expected_isr(END_RIGHT[static_cast<unit8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -635,7 +635,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[Kh910], Left, Right, BeltShift::Unknown, Lace);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh910)], Left, Right, BeltShift::Unknown, Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
@@ -650,7 +650,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[Kh270], Right, Left, BeltShift::Regular, Knit);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh270)], Right, Left, BeltShift::Regular, Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -89,11 +89,11 @@ protected:
   TesterMock *testerMock;
 
   uint8_t get_position_past_left() {
-    return (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
+    return (END_LEFT_PLUS_OFFSET[static_cast<signed char>(encoders->getMachineType())] + GARTER_SLOP) + 1;
   }
 
   uint8_t get_position_past_right() {
-    return (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
+    return (END_RIGHT_MINUS_OFFSET[static_cast<signed char>(encoders->getMachineType())] - GARTER_SLOP) - 1;
   }
 
   void expect_knitter_init() {
@@ -199,7 +199,7 @@ protected:
     get_to_ready(m);
     uint8_t pattern[] = {1};
     EXPECT_CALL(*beeperMock, ready);
-    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
+    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
     expected_dispatch_ready();
 
     // ends in state `OpState::knit`
@@ -283,7 +283,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   ASSERT_EQ(m, Machine_t::NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
-      knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
+      knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -300,7 +300,7 @@ TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_notReady) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1, pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1, pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -335,11 +335,11 @@ TEST_F(KnitterTest, test_startKnitting_failures) {
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
 
   // `m_stopNeedle` out of range
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)], pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)], pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // null pattern
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1, nullptr,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1, nullptr,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -355,7 +355,7 @@ TEST_F(KnitterTest, test_setNextLine) {
   expected_dispatch_knit(true);
 
   // outside of the active needles
-  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(1);
   expected_dispatch_knit(false);
 
@@ -386,8 +386,8 @@ TEST_F(KnitterTest, test_knit_Kh910) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW)); // green LED off
   expected_dispatch();
@@ -404,7 +404,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)];
   expected_isr(8 + STOP_NEEDLE + OFFSET);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -430,8 +430,8 @@ TEST_F(KnitterTest, test_knit_Kh270) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh270)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh270)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh270)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh270)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW));
   expected_dispatch();
@@ -454,7 +454,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh270)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh270)];
   expected_isr(8 + STOP_NEEDLE + OFFSET, Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -478,7 +478,7 @@ TEST_F(KnitterTest, test_knit_line_request) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is set above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1);
+  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1);
 
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expected_dispatch_knit(false);
@@ -505,7 +505,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // `m_lastLineFlag` is `true`
   knitter->setLastLine();
@@ -529,7 +529,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
   uint8_t wanted_pixel =
-      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1;
+      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1;
   knitter->m_firstRun = false;
   knitter->m_direction = Direction_t::Left;
   knitter->m_position = wanted_pixel + knitter->getStartOffset(Direction_t::Right);
@@ -581,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<signed char>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<signed char>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);
@@ -635,7 +635,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[static_cast<int8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
+  expected_isr(END_RIGHT[static_cast<signed char>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
@@ -650,7 +650,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[static_cast<int8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
+  expected_isr(END_RIGHT[static_cast<signed char>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -127,11 +127,11 @@ protected:
   }
 
   void expect_isr(Direction_t dir, Direction_t hall) {
-    expect_isr(1, dir, hall, BeltShift::Regular, Knit);
+    expect_isr(1, dir, hall, BeltShift::Regular, Carriage_t::Knit);
   }
 
   void expected_isr(uint8_t pos, Direction_t dir, Direction_t hall) {
-    expect_isr(pos, dir, hall, BeltShift::Regular, Knit);
+    expect_isr(pos, dir, hall, BeltShift::Regular, Carriage_t::Knit);
     knitter->isr();
   }
 
@@ -141,7 +141,7 @@ protected:
   }
 
   void expect_isr(uint16_t pos) {
-    expect_isr(pos, Right, Left, BeltShift::Regular, Garter);
+    expect_isr(pos, Right, Left, BeltShift::Regular, Carriage_t::Garter);
   }
 
   void expected_isr(uint16_t pos) {
@@ -398,7 +398,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // no useful position calculated by `calculatePixelAndSolenoid()`
-  expected_isr(100, NoDirection, Right, BeltShift::Shifted, Knit);
+  expected_isr(100, NoDirection, Right, BeltShift::Shifted, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(0);
   expect_indState();
   expected_dispatch_knit(false);
@@ -448,7 +448,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // no useful position calculated by `calculatePixelAndSolenoid()`
-  expected_isr(60, NoDirection, Right, BeltShift::Shifted, Knit);
+  expected_isr(60, NoDirection, Right, BeltShift::Shifted, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(0);
   expect_indState();
   expected_dispatch_knit(false);
@@ -545,7 +545,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   knitter->knit();
 
   ASSERT_EQ(knitter->getStartOffset(NUM_DIRECTIONS), 0);
-  knitter->m_carriage = NUM_CARRIAGES;
+  knitter->m_carriage = Carriage_t::NoCarriage;
   ASSERT_EQ(knitter->getStartOffset(Right), 0);
 
   // test expectations without destroying instance
@@ -607,50 +607,50 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_init();
 
   // new position, different beltShift and active hall
-  expected_isr(100, Right, Right, BeltShift::Shifted, Lace);
+  expected_isr(100, Right, Right, BeltShift::Shifted, Carriage_t::Lace);
   expected_dispatch_test();
 
   // no direction, need to change position to enter test
-  expected_isr(101, NoDirection, Right, BeltShift::Shifted, Lace);
+  expected_isr(101, NoDirection, Right, BeltShift::Shifted, Carriage_t::Lace);
   expected_dispatch_test();
 
   // no belt, need to change position to enter test
-  expected_isr(100, Right, Right, BeltShift::Unknown, Lace);
+  expected_isr(100, Right, Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // no belt on left side, need to change position to enter test
-  expected_isr(101, Left, Right, BeltShift::Unknown, Garter);
+  expected_isr(101, Left, Right, BeltShift::Unknown, Carriage_t::Garter);
   expected_dispatch_test();
 
   // left Lace carriage
-  expected_isr(100, Left, Right, BeltShift::Unknown, Lace);
+  expected_isr(100, Left, Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // regular belt on left, need to change position to enter test
-  expected_isr(101, Left, Right, BeltShift::Regular, Garter);
+  expected_isr(101, Left, Right, BeltShift::Regular, Carriage_t::Garter);
   expected_dispatch_test();
 
   // shifted belt on left, need to change position to enter test
-  expected_isr(100, Left, Right, BeltShift::Shifted, Garter);
+  expected_isr(100, Left, Right, BeltShift::Shifted, Carriage_t::Garter);
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh910)], Left, Right, BeltShift::Unknown, Lace);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh910)], Left, Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
-  expected_isr(39, Right, Left, BeltShift::Unknown, Lace);
+  expected_isr(39, Right, Left, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // KH270
   knitter->setMachineType(Machine_t::Kh270);
 
   // K carriage direction left
-  expected_isr(0, Left, Right, BeltShift::Regular, Knit);
+  expected_isr(0, Left, Right, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh270)], Right, Left, BeltShift::Regular, Knit);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh270)], Right, Left, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance
@@ -662,18 +662,16 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
 
 TEST_F(KnitterTest, test_getStartOffset) {
   // out of range values
-  knitter->m_carriage = Knit;
+  knitter->m_carriage = Carriage_t::Knit;
   ASSERT_EQ(knitter->getStartOffset(NoDirection), 0);
 
   ASSERT_EQ(knitter->getStartOffset(NUM_DIRECTIONS), 0);
 
-  knitter->m_carriage = NoCarriage;
+  knitter->m_carriage = Carriage_t::NoCarriage;
   ASSERT_EQ(knitter->getStartOffset(Left), 0);
-
-  knitter->m_carriage = NUM_CARRIAGES;
   ASSERT_EQ(knitter->getStartOffset(Right), 0);
 
-  knitter->m_carriage = Lace;
+  knitter->m_carriage = Carriage_t::Lace;
   knitter->m_machineType = Machine_t::NoMachine;
   ASSERT_EQ(knitter->getStartOffset(Left), 0);
   ASSERT_EQ(knitter->getStartOffset(Right), 0);

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -89,11 +89,11 @@ protected:
   TesterMock *testerMock;
 
   uint8_t get_position_past_left() {
-    return (END_LEFT_PLUS_OFFSET[static_cast<unit8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
+    return (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
   }
 
   uint8_t get_position_past_right() {
-    return (END_RIGHT_MINUS_OFFSET[static_cast<unit8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
+    return (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
   }
 
   void expect_knitter_init() {
@@ -199,7 +199,7 @@ protected:
     get_to_ready(m);
     uint8_t pattern[] = {1};
     EXPECT_CALL(*beeperMock, ready);
-    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
+    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
     expected_dispatch_ready();
 
     // ends in state `OpState::knit`
@@ -283,7 +283,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   ASSERT_EQ(m, Machine_t::NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
-      knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
+      knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -300,7 +300,7 @@ TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_notReady) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1, pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -335,11 +335,11 @@ TEST_F(KnitterTest, test_startKnitting_failures) {
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
 
   // `m_stopNeedle` out of range
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)], pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)], pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // null pattern
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1, nullptr,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, nullptr,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -355,7 +355,7 @@ TEST_F(KnitterTest, test_setNextLine) {
   expected_dispatch_knit(true);
 
   // outside of the active needles
-  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(1);
   expected_dispatch_knit(false);
 
@@ -386,8 +386,8 @@ TEST_F(KnitterTest, test_knit_Kh910) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW)); // green LED off
   expected_dispatch();
@@ -404,7 +404,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)];
   expected_isr(8 + STOP_NEEDLE + OFFSET);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -430,8 +430,8 @@ TEST_F(KnitterTest, test_knit_Kh270) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh270)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh270)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW));
   expected_dispatch();
@@ -454,7 +454,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh270)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh270)];
   expected_isr(8 + STOP_NEEDLE + OFFSET, Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -478,7 +478,7 @@ TEST_F(KnitterTest, test_knit_line_request) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is set above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1);
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1);
 
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expected_dispatch_knit(false);
@@ -505,7 +505,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // `m_lastLineFlag` is `true`
   knitter->setLastLine();
@@ -529,7 +529,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
   uint8_t wanted_pixel =
-      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1;
+      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1;
   knitter->m_firstRun = false;
   knitter->m_direction = Direction_t::Left;
   knitter->m_position = wanted_pixel + knitter->getStartOffset(Direction_t::Right);
@@ -581,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<unit8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<unit8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);
@@ -635,7 +635,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[static_cast<unit8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
@@ -650,7 +650,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[static_cast<unit8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
+  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -280,7 +280,7 @@ TEST_F(KnitterTest, test_isr) {
 TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   uint8_t pattern[] = {1};
   Machine_t m = knitter->getMachineType();
-  ASSERT_EQ(m, NoMachine);
+  ASSERT_EQ(m, Machine_t::NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
       knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
@@ -291,7 +291,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->initMachine(NUM_MACHINES) != ErrorCode::SUCCESS);
+  ASSERT_TRUE(knitter->initMachine(Machine_t::NoMachine) != ErrorCode::SUCCESS);
   ASSERT_TRUE(knitter->startKnitting(0, 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -335,11 +335,11 @@ TEST_F(KnitterTest, test_startKnitting_failures) {
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
 
   // `m_stopNeedle` out of range
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[Kh910], pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)], pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // null pattern
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[Kh910] - 1, nullptr,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, nullptr,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -355,7 +355,7 @@ TEST_F(KnitterTest, test_setNextLine) {
   expected_dispatch_knit(true);
 
   // outside of the active needles
-  expected_isr(NUM_NEEDLES[Kh910] + END_OF_LINE_OFFSET_R[Kh910] + 1 + knitter->getStartOffset(Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Left));
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(1);
   expected_dispatch_knit(false);
 

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -581,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -89,13 +89,11 @@ protected:
   TesterMock *testerMock;
 
   uint8_t get_position_past_left() {
-    Machine_t type = knitter->getMachineType();
-    return (END_LEFT_PLUS_OFFSET[type] + GARTER_SLOP) + 1;
+    return (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
   }
 
   uint8_t get_position_past_right() {
-    Machine_t type = knitter->getMachineType();
-    return (END_RIGHT_MINUS_OFFSET[type] - GARTER_SLOP) - 1;
+    return (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
   }
 
   void expect_knitter_init() {
@@ -201,7 +199,7 @@ protected:
     get_to_ready(m);
     uint8_t pattern[] = {1};
     EXPECT_CALL(*beeperMock, ready);
-    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[m] - 1, pattern, false), ErrorCode::SUCCESS);
+    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
     expected_dispatch_ready();
 
     // ends in state `OpState::knit`
@@ -210,7 +208,7 @@ protected:
 
   void expected_dispatch_knit(bool first) {
     if (first) {
-      get_to_knit(Kh910);
+      get_to_knit(Machine_t::Kh910);
       expect_first_knit();
       EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, HIGH)); // green LED on
       expected_dispatch();
@@ -285,7 +283,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   ASSERT_EQ(m, NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
-      knitter->startKnitting(0, NUM_NEEDLES[m] - 1, pattern, false) != ErrorCode::SUCCESS);
+      knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -310,7 +308,7 @@ TEST_F(KnitterTest, test_startKnitting_notReady) {
 }
 
 TEST_F(KnitterTest, test_startKnitting_Kh910) {
-  get_to_knit(Kh910);
+  get_to_knit(Machine_t::Kh910);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -320,7 +318,7 @@ TEST_F(KnitterTest, test_startKnitting_Kh910) {
 }
 
 TEST_F(KnitterTest, test_startKnitting_Kh270) {
-  get_to_knit(Kh270);
+  get_to_knit(Machine_t::Kh270);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -331,7 +329,7 @@ TEST_F(KnitterTest, test_startKnitting_Kh270) {
 
 TEST_F(KnitterTest, test_startKnitting_failures) {
   uint8_t pattern[] = {1};
-  get_to_ready(Kh910);
+  get_to_ready(Machine_t::Kh910);
 
   // `m_stopNeedle` lower than `m_startNeedle`
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
@@ -381,15 +379,15 @@ TEST_F(KnitterTest, test_setNextLine) {
 }
 
 TEST_F(KnitterTest, test_knit_Kh910) {
-  get_to_ready(Kh910);
+  get_to_ready(Machine_t::Kh910);
 
   // knit
   uint8_t pattern[] = {1};
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[Kh910] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[Kh910] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW)); // green LED off
   expected_dispatch();
@@ -406,7 +404,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[Kh910];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)];
   expected_isr(8 + STOP_NEEDLE + OFFSET);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -425,15 +423,15 @@ TEST_F(KnitterTest, test_knit_Kh910) {
 }
 
 TEST_F(KnitterTest, test_knit_Kh270) {
-  get_to_ready(Kh270);
+  get_to_ready(Machine_t::Kh270);
 
   // knit
   uint8_t pattern[] = {1};
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[Kh270] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[Kh270] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW));
   expected_dispatch();
@@ -456,7 +454,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[Kh270];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh270)];
   expected_isr(8 + STOP_NEEDLE + OFFSET, Right, Left, BeltShift::Regular, Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -480,7 +478,7 @@ TEST_F(KnitterTest, test_knit_line_request) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is set above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[Kh910] + 8 + END_OF_LINE_OFFSET_R[Kh910] + 1);
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1);
 
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expected_dispatch_knit(false);
@@ -507,7 +505,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[Kh910] + END_OF_LINE_OFFSET_R[Kh910] + 1 + knitter->getStartOffset(Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Left));
 
   // `m_lastLineFlag` is `true`
   knitter->setLastLine();
@@ -531,7 +529,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
   uint8_t wanted_pixel =
-      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[Kh910] + 1;
+      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1;
   knitter->m_firstRun = false;
   knitter->m_direction = Left;
   knitter->m_position = wanted_pixel + knitter->getStartOffset(Right);
@@ -583,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[Kh910] + END_OF_LINE_OFFSET_R[Kh910] + 1 + knitter->getStartOffset(Left));
+  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);
@@ -604,7 +602,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
 TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   // initialize
-  expected_init_machine(Kh910);
+  expected_init_machine(Machine_t::Kh910);
   fsm->setState(OpState::test);
   expected_dispatch_init();
 
@@ -645,7 +643,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // KH270
-  knitter->setMachineType(Kh270);
+  knitter->setMachineType(Machine_t::Kh270);
 
   // K carriage direction left
   expected_isr(0, Left, Right, BeltShift::Regular, Knit);
@@ -687,7 +685,7 @@ TEST_F(KnitterTest, test_getStartOffset) {
 }
 
 TEST_F(KnitterTest, test_fsm_init_LL) {
-  expected_init_machine(Kh910);
+  expected_init_machine(Machine_t::Kh910);
 
   // not ready
   expected_isr(get_position_past_right(), Left, Left);
@@ -701,7 +699,7 @@ TEST_F(KnitterTest, test_fsm_init_LL) {
 }
 
 TEST_F(KnitterTest, test_fsm_init_RR) {
-  expected_init_machine(Kh910);
+  expected_init_machine(Machine_t::Kh910);
 
   // still not ready
   expected_isr(get_position_past_left(), Right, Right);
@@ -715,7 +713,7 @@ TEST_F(KnitterTest, test_fsm_init_RR) {
 }
 
 TEST_F(KnitterTest, test_fsm_init_RL) {
-  expected_init_machine(Kh910);
+  expected_init_machine(Machine_t::Kh910);
 
   // Machine is initialized when Left hall sensor
   // is passed in Right direction inside active needles.
@@ -729,7 +727,7 @@ TEST_F(KnitterTest, test_fsm_init_RL) {
 }
 
 TEST_F(KnitterTest, test_fsm_init_LR) {
-  expected_init_machine(Kh910);
+  expected_init_machine(Machine_t::Kh910);
 
   // New feature (August 2020): the machine is also initialized
   // when the right Hall sensor is passed in the Left direction.

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -89,11 +89,11 @@ protected:
   TesterMock *testerMock;
 
   uint8_t get_position_past_left() {
-    return (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
+    return (END_LEFT_PLUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())] + GARTER_SLOP) + 1;
   }
 
   uint8_t get_position_past_right() {
-    return (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
+    return (END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())] - GARTER_SLOP) - 1;
   }
 
   void expect_knitter_init() {
@@ -199,7 +199,7 @@ protected:
     get_to_ready(m);
     uint8_t pattern[] = {1};
     EXPECT_CALL(*beeperMock, ready);
-    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
+    ASSERT_EQ(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(m)] - 1, pattern, false), ErrorCode::SUCCESS);
     expected_dispatch_ready();
 
     // ends in state `OpState::knit`
@@ -283,7 +283,7 @@ TEST_F(KnitterTest, test_startKnitting_NoMachine) {
   ASSERT_EQ(m, Machine_t::NoMachine);
   ASSERT_TRUE(knitter->initMachine(m) != ErrorCode::SUCCESS);
   ASSERT_TRUE(
-      knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
+      knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(m)] - 1, pattern, false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(solenoidsMock));
@@ -300,7 +300,7 @@ TEST_F(KnitterTest, test_startKnitting_invalidMachine) {
 
 TEST_F(KnitterTest, test_startKnitting_notReady) {
   uint8_t pattern[] = {1};
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1, pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -335,11 +335,11 @@ TEST_F(KnitterTest, test_startKnitting_failures) {
   ASSERT_TRUE(knitter->startKnitting(1, 0, pattern, false) != ErrorCode::SUCCESS);
 
   // `m_stopNeedle` out of range
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)], pattern,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)], pattern,
                                      false) != ErrorCode::SUCCESS);
 
   // null pattern
-  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1, nullptr,
+  ASSERT_TRUE(knitter->startKnitting(0, NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1, nullptr,
                                      false) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
@@ -355,7 +355,7 @@ TEST_F(KnitterTest, test_setNextLine) {
   expected_dispatch_knit(true);
 
   // outside of the active needles
-  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
   EXPECT_CALL(*solenoidsMock, setSolenoid).Times(1);
   expected_dispatch_knit(false);
 
@@ -386,8 +386,8 @@ TEST_F(KnitterTest, test_knit_Kh910) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW)); // green LED off
   expected_dispatch();
@@ -404,7 +404,7 @@ TEST_F(KnitterTest, test_knit_Kh910) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)];
   expected_isr(8 + STOP_NEEDLE + OFFSET);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -430,8 +430,8 @@ TEST_F(KnitterTest, test_knit_Kh270) {
 
   // `m_startNeedle` is greater than `m_pixelToSet`
   EXPECT_CALL(*beeperMock, ready);
-  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 2;
-  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh270)] - 1;
+  const uint8_t START_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh270)] - 2;
+  const uint8_t STOP_NEEDLE = NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh270)] - 1;
   knitter->startKnitting(START_NEEDLE, STOP_NEEDLE, pattern, true);
   EXPECT_CALL(*arduinoMock, digitalWrite(LED_PIN_A, LOW));
   expected_dispatch();
@@ -454,7 +454,7 @@ TEST_F(KnitterTest, test_knit_Kh270) {
   expected_dispatch_knit(false);
 
   // don't set `m_workedonline` to `true`
-  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh270)];
+  const uint8_t OFFSET = END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh270)];
   expected_isr(8 + STOP_NEEDLE + OFFSET, Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expect_indState();
@@ -478,7 +478,7 @@ TEST_F(KnitterTest, test_knit_line_request) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is set above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1);
+  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + 8 + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1);
 
   EXPECT_CALL(*solenoidsMock, setSolenoid);
   expected_dispatch_knit(false);
@@ -505,7 +505,7 @@ TEST_F(KnitterTest, test_knit_lastLine) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // `m_lastLineFlag` is `true`
   knitter->setLastLine();
@@ -529,7 +529,7 @@ TEST_F(KnitterTest, test_knit_lastLine_and_no_req) {
   // Note: probing private data and methods to get full branch coverage.
   knitter->m_stopNeedle = 100;
   uint8_t wanted_pixel =
-      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1;
+      knitter->m_stopNeedle + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1;
   knitter->m_firstRun = false;
   knitter->m_direction = Direction_t::Left;
   knitter->m_position = wanted_pixel + knitter->getStartOffset(Direction_t::Right);
@@ -581,7 +581,7 @@ TEST_F(KnitterTest, test_knit_new_line) {
 
   // Position has changed since last call to operate function
   // `m_pixelToSet` is above `m_stopNeedle` + END_OF_LINE_OFFSET_R
-  expected_isr(NUM_NEEDLES[static_cast<uint8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<uint8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
+  expected_isr(NUM_NEEDLES[static_cast<int8_t>(Machine_t::Kh910)] + END_OF_LINE_OFFSET_R[static_cast<int8_t>(Machine_t::Kh910)] + 1 + knitter->getStartOffset(Direction_t::Left));
 
   // set `m_lineRequested` to `false`
   EXPECT_CALL(*beeperMock, finishedLine);
@@ -635,7 +635,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // off of right end, position is changed
-  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
+  expected_isr(END_RIGHT[static_cast<int8_t>(Machine_t::Kh910)], Direction_t::Left, Direction_t::Right, BeltShift::Unknown, Carriage_t::Lace);
   expected_dispatch_test();
 
   // direction right, have not reached offset
@@ -650,7 +650,7 @@ TEST_F(KnitterTest, test_calculatePixelAndSolenoid) {
   expected_dispatch_test();
 
   // K carriage direction right
-  expected_isr(END_RIGHT[static_cast<uint8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
+  expected_isr(END_RIGHT[static_cast<int8_t>(Machine_t::Kh270)], Direction_t::Right, Direction_t::Left, BeltShift::Regular, Carriage_t::Knit);
   expected_dispatch_test();
 
   // test expectations without destroying instance

--- a/test/test_tester.cpp
+++ b/test/test_tester.cpp
@@ -77,7 +77,7 @@ protected:
     // `setUp()` must have been called to reach `millis()`
     EXPECT_CALL(*arduinoMock, millis).WillOnce(Return(t));
 
-    ASSERT_TRUE(tester->startTest(Kh930) == ErrorCode::SUCCESS);
+    ASSERT_TRUE(tester->startTest(Machine_t::Kh930) == ErrorCode::SUCCESS);
   }
 
   void expect_write(bool once) {

--- a/test/test_tester.cpp
+++ b/test/test_tester.cpp
@@ -71,7 +71,7 @@ protected:
   void expect_startTest(unsigned long t) {
     EXPECT_CALL(*fsmMock, getState).WillOnce(Return(OpState::ready));
     EXPECT_CALL(*fsmMock, setState(OpState::test));
-    EXPECT_CALL(*knitterMock, setMachineType(Kh930));
+    EXPECT_CALL(*knitterMock, setMachineType(Machine_t::Kh930));
     expect_write(false);
 
     // `setUp()` must have been called to reach `millis()`

--- a/test/test_tester.cpp
+++ b/test/test_tester.cpp
@@ -245,7 +245,7 @@ TEST_F(TesterTest, test_loop_autoTest) {
 TEST_F(TesterTest, test_startTest_fail) {
   // can't start test from state `OpState::knit`
   EXPECT_CALL(*fsmMock, getState).WillOnce(Return(OpState::knit));
-  ASSERT_TRUE(tester->startTest(Kh910) != ErrorCode::SUCCESS);
+  ASSERT_TRUE(tester->startTest(Machine_t::Kh910) != ErrorCode::SUCCESS);
 
   // test expectations without destroying instance
   ASSERT_TRUE(Mock::VerifyAndClear(fsmMock));


### PR DESCRIPTION
Migrate from `enum Machine` to `enum class Machine`,  `enum Carriage` to `enum class Carriage`,  `enum Direction` to `enum class Direction`