### PR TITLE
EOL refactor prototype

### DIFF
--- a/boards/ayab-esp32.json
+++ b/boards/ayab-esp32.json
@@ -2,7 +2,7 @@
     "build": {
       "arduino":{
         "ldscript": "esp32s3_out.ld",
-        "partitions": "partitions-4MB-tinyuf2.csv"
+        "partitions": "default.csv"
       },
       "core": "esp32",
       "extra_flags": [

--- a/src/ayab/board.h
+++ b/src/ayab/board.h
@@ -38,6 +38,8 @@ constexpr uint16_t START_KNITTING_DELAY = 2000U; // ms
 // Arduino Uno
 
 #define HAS_MCP23008
+#define EOL_ANALOG
+
 constexpr uint8_t I2Caddr_sol1_8 = 0x0U;  ///< I2C Address of solenoids 1 - 8
 constexpr uint8_t I2Caddr_sol9_16 = 0x1U; ///< I2C Address of solenoids 9 - 16
 
@@ -57,6 +59,8 @@ constexpr uint8_t PIEZO_PIN = 9;
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)// ESP32-S3 (AYAB-ESP32)
 
 #define HAS_MCP23017
+#define EOL_COMPARATOR
+
 constexpr uint8_t MCP23017_ADDR_0 = 0x0U; // I2C address of expander on ayab-esp32 (16-wide)
 
 // Knitting machine control
@@ -87,7 +91,8 @@ constexpr uint8_t I2C_PIN_SCL = 16;  // I2C1
 
 // Misc I/O
 constexpr uint8_t LED_PIN_R = 33;  
-constexpr uint8_t LED_PIN_G = 34;   
+constexpr uint8_t LED_PIN_A = 33;
+constexpr uint8_t LED_PIN_G = 34;
 constexpr uint8_t LED_PIN_B = 35;    
 
 constexpr uint8_t PIEZO_PIN = 38;

--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -96,19 +96,28 @@ void Com::send_reqLine(const uint8_t lineNumber, Err_t error) const {
  * \param position Position of knitting carriage in needles from left hand side.
  * \param initState State of readiness (0 = ready, other values = not ready).
  */
-void Com::send_indState(Carriage_t carriage, uint8_t position,
-                        Err_t error) const {
-  uint16_t leftHallValue = GlobalEncoders::getHallValue(Direction_t::Left);
-  uint16_t rightHallValue = GlobalEncoders::getHallValue(Direction_t::Right);
+void Com::send_indState(Carriage_t carriage, uint8_t position, Err_t error) const {
+  #if defined(EOL_ANALOG)
+  uint16_t leftHallValueAnalog = analogRead(EOL_PIN_L);
+  uint16_t rightHallValueAnalog = analogRead(EOL_PIN_R);
+
+  #elif defined(EOL_COMPARATOR)
+  // There are no analog values for the comparator type board.
+  uint16_t leftHallValueAnalog = 0xFFFF;
+  uint16_t rightHallValueAnalog = 0xFFFF;
+
+  #endif
   // `payload` will be allocated on stack since length is compile-time constant
   uint8_t payload[INDSTATE_LEN] = {
       static_cast<uint8_t>(AYAB_API::indState),
       static_cast<uint8_t>(error),
       static_cast<uint8_t>(GlobalFsm::getState()),
-      highByte(leftHallValue),
-      lowByte(leftHallValue),
-      highByte(rightHallValue),
-      lowByte(rightHallValue),
+      highByte(leftHallValueAnalog),
+      lowByte(leftHallValueAnalog),
+      highByte(rightHallValueAnalog),
+      lowByte(rightHallValueAnalog),
+      static_cast<uint8_t>(GlobalEncoders::getHallValue(Direction_t::Left)),
+      static_cast<uint8_t>(GlobalEncoders::getHallValue(Direction_t::Right)),
       static_cast<uint8_t>(carriage),
       position,
       static_cast<uint8_t>(GlobalEncoders::getDirection()),

--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -75,7 +75,7 @@ enum class AYAB_API : unsigned char {
 using AYAB_API_t = enum AYAB_API;
 
 // API constants
-constexpr uint8_t INDSTATE_LEN = 10U;
+constexpr uint8_t INDSTATE_LEN = 12U;
 constexpr uint8_t REQLINE_LEN = 3U;
 
 class ComInterface {

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -27,7 +27,13 @@
 #include <Arduino.h>
 
 // Enumerated constants
-
+enum class HallState : unsigned char {
+  None = 0,
+  North = 1,
+  South = 2,
+  Error = 0xFF
+};
+using HallState_t = enum HallState;
 
 enum class Direction : unsigned char {
   NoDirection = 0xFF,
@@ -123,7 +129,7 @@ public:
 
   // any methods that need to be mocked should go here
   virtual void encA_interrupt() = 0;
-  virtual uint16_t getHallValue(Direction_t pSensor) = 0;
+  virtual HallState_t getHallValue(Direction_t pSensor) = 0;
   virtual void init(Machine_t machineType) = 0;
   virtual Machine_t getMachineType() = 0;
   virtual BeltShift_t getBeltShift() = 0;
@@ -148,7 +154,7 @@ public:
   static EncodersInterface *m_instance;
 
   static void encA_interrupt();
-  static uint16_t getHallValue(Direction_t pSensor);
+  static HallState_t getHallValue(Direction_t pSensor);
   static void init(Machine_t machineType);
   static Machine_t getMachineType();
   static BeltShift_t getBeltShift();
@@ -163,7 +169,7 @@ public:
   Encoders() = default;
 
   void encA_interrupt() final;
-  uint16_t getHallValue(Direction_t pSensor) final;
+  HallState_t getHallValue(Direction_t pSensor) final;
   void init(Machine_t machineType) final;
   Machine_t getMachineType() final;
   BeltShift_t getBeltShift() final;

--- a/src/ayab/global_encoders.cpp
+++ b/src/ayab/global_encoders.cpp
@@ -29,7 +29,7 @@ void GlobalEncoders::encA_interrupt() {
   m_instance->encA_interrupt();
 }
 
-uint16_t GlobalEncoders::getHallValue(Direction_t pSensor) {
+HallState_t GlobalEncoders::getHallValue(Direction_t pSensor) {
   return m_instance->getHallValue(pSensor);
 }
 

--- a/src/ayab/solenoids.cpp
+++ b/src/ayab/solenoids.cpp
@@ -29,7 +29,7 @@
  * \brief Initialize I2C connection for solenoids.
  */
 void Solenoids::init() {
-  #ifdef HAS_MCP23008
+  #if defined(HAS_MCP23008)
   mcp_0.begin_I2C(I2Caddr_sol1_8);
   mcp_1.begin_I2C(I2Caddr_sol9_16);
 
@@ -38,7 +38,7 @@ void Solenoids::init() {
     mcp_1.pinMode(i, OUTPUT);
   }
 
-  #elif HAS_MCP23017
+  #elif defined(HAS_MCP23017)
   mcp.begin_I2C(MCP23017_ADDR_0);
 
   for (uint8_t i = 0; i < SOLENOID_BUFFER_SIZE; i++){
@@ -117,9 +117,10 @@ void Solenoids::write(uint16_t newState) {
   uint16_t bankA = (newState >> 8); // map solenoids 8..F to 0..7 GPIO A
 
   uint16_t bankB = 0;
-  for(uint8_t i = 0; i < 8; i++){
+  for(uint16_t i = 0; i < 8; i++){
     // Need to reverse the bits of the upper byte (which is located in the lower byte)
-    bankB[i+8] = (newState >> (7-i)) & 0x01;
+    bankB |= (newState >> (7-i)) & 0x01;
+    bankB << 1;
   }
 
   mcp.writeGPIOAB(bankA & bankB);

--- a/src/ayab/tester.cpp
+++ b/src/ayab/tester.cpp
@@ -252,12 +252,25 @@ void Tester::readEncoders() const {
  * \brief Read the End of Line sensors.
  */
 void Tester::readEOLsensors() {
+  #if defined(EOL_ANALOG)
+
   auto hallSensor = static_cast<uint16_t>(analogRead(EOL_PIN_L));
   snprintf(buf, BUFFER_LEN, "  EOL_L: %hu", hallSensor);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
   hallSensor = static_cast<uint16_t>(analogRead(EOL_PIN_R));
   snprintf(buf, BUFFER_LEN, "  EOL_R: %hu", hallSensor);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
+
+  #elif defined (EOL_COMPARATOR)
+  // Not sure how we want to handle this. I think it's not a bad idea to just return whether the state is none, North, or South.
+  auto hallSensor = static_cast<uint16_t>(GlobalEncoders::getHallValue(Direction_t::Left));
+  snprintf(buf, BUFFER_LEN, "  EOL_L: %hu", hallSensor);
+  GlobalCom::sendMsg(AYAB_API::testRes, buf);
+  hallSensor = static_cast<uint16_t>(GlobalEncoders::getHallValue(Direction_t::Right));
+  snprintf(buf, BUFFER_LEN, "  EOL_R: %hu", hallSensor);
+  GlobalCom::sendMsg(AYAB_API::testRes, buf);
+
+  #endif
 }
 
 /*!


### PR DESCRIPTION
What do you think?
The main idea is to remove the filtering from the encoder code, and instead only work with a new enum HallState which indicates if the hall sensor is inactive, reading north, or reading south. This successfully builds for both Uno and ESP32 environments. I still need to check if I associated the right transitions to the right carriages.

I have also snuck in a small change here to the ayab-esp32 board definition of PIO, changing partition to "default.csv" as the reference board I took it from was outdated.