### PR TITLE
930 bug fixes for garter carriage alignment and lace carriage start selection

### DIFF
--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -89,8 +89,8 @@ constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
     // KH930
     {
         // K,   L,   G
-        {40U, 40U,  8U}, // Left
-        {16U, 16U, 32U} // Right
+        {40U, 40U, 32U}, // Left
+        {16U, 16U, 56U} // Right
     },
     // KH270
     {

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -395,7 +395,16 @@ bool Knitter::calculatePixelAndSolenoid() {
   // magic numbers from machine manual
   case Direction_t::Right:
     startOffset = getStartOffset(Direction_t::Left);
-    if (m_position >= startOffset) {
+    uint8_t pixelStartOffset = startOffset;
+
+    // We have to start setting pixels earlier when the lace carriage is selected because we shift
+    // the lace pixel selection up HALF_SOLENOIDS_NUM in this direction. Doesn't matter going back 
+    // the other way.
+    if (Carriage_t::Lace == m_carriage) {
+      pixelStartOffset = pixelStartOffset - HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+    }
+
+    if (m_position >= pixelStartOffset) {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {
@@ -432,6 +441,7 @@ bool Knitter::calculatePixelAndSolenoid() {
   default:
     return false;
   }
+
   // The 270 has 12 solenoids but they get shifted over 3 bits
   if (m_machineType == Machine_t::Kh270) {
     m_solenoidToSet = m_solenoidToSet + 3;

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -388,6 +388,7 @@ void Knitter::reqLine(uint8_t lineNumber) {
  */
 bool Knitter::calculatePixelAndSolenoid() {
   uint8_t startOffset = 0;
+  uint8_t laceOffset = 0;
 
   switch (m_direction) {
   // calculate the solenoid and pixel to be set
@@ -395,16 +396,15 @@ bool Knitter::calculatePixelAndSolenoid() {
   // magic numbers from machine manual
   case Direction_t::Right:
     startOffset = getStartOffset(Direction_t::Left);
-    uint8_t pixelStartOffset = startOffset;
 
     // We have to start setting pixels earlier when the lace carriage is selected because we shift
     // the lace pixel selection up HALF_SOLENOIDS_NUM in this direction. Doesn't matter going back 
     // the other way.
     if (Carriage_t::Lace == m_carriage) {
-      pixelStartOffset = pixelStartOffset - HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
+      laceOffset = HALF_SOLENOIDS_NUM[static_cast<uint8_t>(m_machineType)];
     }
 
-    if (m_position >= pixelStartOffset) {
+    if (m_position >= startOffset - laceOffset) {
       m_pixelToSet = m_position - startOffset;
 
       if ((BeltShift::Regular == m_beltShift) || (m_machineType == Machine_t::Kh270)) {


### PR DESCRIPTION
Update offsets for G carriage on the 930

Make sure to calculate the first HALF_SOLENOID pixels when the lace carriage is selected.

Addresses: 
- https://github.com/AllYarnsAreBeautiful/ayab-firmware/issues/180
- https://github.com/AllYarnsAreBeautiful/ayab-firmware/issues/178

