### PR TITLE
Add support for G-carriage detection

### DIFF
--- a/ayab.ino
+++ b/ayab.ino
@@ -163,6 +163,8 @@ void setup() {
   packetSerial.begin(SERIAL_BAUDRATE);
   packetSerial.setPacketHandler(&onPacketReceived);
 
+  knitter = new Knitter(&packetSerial);
+
   pinMode(ENC_PIN_A, INPUT);
   pinMode(ENC_PIN_B, INPUT);
   pinMode(ENC_PIN_C, INPUT);
@@ -176,8 +178,6 @@ void setup() {
 
   // Attaching ENC_PIN_A(=2), Interrupt No. 0
   attachInterrupt(0, isr_encA, CHANGE);
-
-  knitter = new Knitter(&packetSerial);
 }
 
 

--- a/encoders.h
+++ b/encoders.h
@@ -24,6 +24,7 @@ This file is part of AYAB.
 
 #include "Arduino.h"
 #include "./settings.h"
+#include "./hallsensor.h"
 
 class Encoders{
  public:
@@ -41,13 +42,12 @@ class Encoders{
 
  private:
   Direction_t   m_direction;
-  Direction_t   m_hallActive;
   Beltshift_t   m_beltShift;
   Carriage_t    m_carriage;
   byte          m_encoderPos;
 
-  void encA_rising();
-  void encA_falling();
-};
+  HallSensor    *m_leftHallSensor;
+  HallSensor    *m_rightHallSensor;
+  };
 
 #endif  // ENCODERS_H_

--- a/hallsensor.cpp
+++ b/hallsensor.cpp
@@ -1,0 +1,114 @@
+#include "Arduino.h"
+
+#include "./hallsensor.h"
+
+HallSensor::HallSensor(int pin) {
+  _pin = pin;
+  _sensorValue = analogRead(_pin);
+  
+  carriage = NoCarriage;
+  _init();
+}
+
+void HallSensor::setThresholds(uint16_t low, uint16_t high) {
+  _thresholdLow = low;
+  _thresholdHigh = high;
+}
+
+bool HallSensor::isDetected(byte &position, Direction_t &direction) {
+
+  bool isDetected = false;
+
+  _sensorValue = getValue();
+
+  switch (_state) {
+    case ST_IDLE:
+      _state = ST_HUNT;
+      _direction = direction;
+      _needlesToGo = MAX_DET_NEEDLES;
+
+      if (_sensorValue < _thresholdLow) {
+        _minimum = {.value = _sensorValue, .position = position, .isFirst = true};
+      } else if (_sensorValue > _thresholdHigh) {
+        _maximum = {.value = _sensorValue, .position = position, .isFirst = true};
+      } else {
+        _state = ST_IDLE;
+      }
+      break;
+
+    default: // ST_HUNT
+      // Bail out if direction changed
+      if (_direction != direction) {
+         _init();
+         break;
+      }
+
+      // Record minimum position
+      if (_sensorValue < _thresholdLow) {
+        if ((_minimum.value == NONE) || (_sensorValue < _minimum.value)) {
+          _minimum.value    = _sensorValue;
+          _minimum.position = position;
+          if (_maximum.value == NONE) { // Adjust trigger position to the extremum
+            _needlesToGo = MAX_DET_NEEDLES;
+          }
+        }
+      }
+      // Record maximum position
+      if (_sensorValue > _thresholdHigh) {
+        if ((_maximum.value == NONE) || (_sensorValue > _maximum.value)) {
+          _maximum.value    = _sensorValue;
+          _maximum.position = position;
+          if (_minimum.value == NONE) { // Adjust trigger position to the extremum
+            _needlesToGo = MAX_DET_NEEDLES;
+          }
+        }
+      }
+
+     // Select carriage once max. needles passed
+      _needlesToGo--;
+      if (_needlesToGo == 0) {
+        isDetected = _detectCarriage();
+        _init();
+      }
+  }
+  return isDetected;
+}
+
+bool HallSensor::isActive() {
+  return _state != ST_IDLE;
+}
+
+uint16_t HallSensor::getValue() {
+  // Return stored value rather than thru another analogRead (time-consuming/blocking) ?
+  // => only updated when upon isActive() calls
+  //return _sensorValue;
+  return  analogRead(_pin);
+}
+
+void HallSensor::_init() {
+  _state = ST_IDLE;
+  _minimum = {.value = NONE, .position = NONE, .isFirst = false};
+  _maximum = {.value = NONE, .position = NONE, .isFirst = false};
+}
+
+bool HallSensor::_detectCarriage() {
+  bool isDetected = true;
+
+  // K Carriage (only a maximum/North pole)
+  if (_minimum.value == NONE) {
+    carriage = K;
+    position = (byte) (_maximum.position & 0xff);
+  // L Carriage (only a minimum/South pole)
+  } else if (_maximum.value == NONE) {
+    carriage = L;
+    position = (byte) (_minimum.position & 0xff);
+  // G Carriage (maximum/North followed by minimum/South poles)
+  } else if (_maximum.isFirst) {
+    carriage = G;
+    position = (byte) (((_minimum.position + _maximum.position) >> 1) & 0xff);
+  } else {
+    isDetected = false;
+  }
+
+  return isDetected;
+}

--- a/hallsensor.h
+++ b/hallsensor.h
@@ -1,0 +1,43 @@
+#include "Arduino.h"
+#include "./settings.h" 
+
+#define MAX_DET_NEEDLES 3
+#define NONE 0xffff
+
+#define ST_IDLE 0
+#define ST_HUNT 1
+
+struct Extremum {
+  uint16_t value;
+  uint16_t position;
+  bool     isFirst;
+};
+
+class HallSensor {
+  public:
+    HallSensor(int pin);
+
+    Carriage_t  carriage;
+    byte        position;
+    Beltshift_t beltShift;
+
+    void setThresholds(uint16_t low, uint16_t high);
+    bool isDetected(byte &position, Direction_t &direction);
+    bool isActive();
+    uint16_t getValue();
+
+  private:
+    int _pin;
+    uint16_t _sensorValue;
+    uint16_t _thresholdLow;
+    uint16_t _thresholdHigh;
+
+    byte        _state;
+    Extremum    _minimum;
+    Extremum    _maximum;
+    Direction_t _direction;
+    int         _needlesToGo;
+
+    void _init();
+    bool _detectCarriage();
+};

--- a/knitter.cpp
+++ b/knitter.cpp
@@ -32,6 +32,7 @@ Knitter::Knitter(SLIPPacketSerial* packetSerial) {
   m_stopNeedle        = 0;
   m_currentLineNumber = 0;
   m_lineRequested     = false;
+  m_carriage          = NoCarriage;
 
   m_solenoids.init();
 }
@@ -41,7 +42,6 @@ void Knitter::isr() {
   m_encoders.encA_interrupt();
   m_position   = m_encoders.getPosition();
   m_direction  = m_encoders.getDirection();
-  m_hallActive = m_encoders.getHallActive();
   m_beltshift  = m_encoders.getBeltshift();
   m_carriage   = m_encoders.getCarriage();
 }
@@ -149,9 +149,8 @@ void Knitter::state_init() {
   }
   _prevState = state;
 #else
-  // Machine is initialized when left hall sensor is passed in Right direction
-  if (Right == m_direction
-      && Left == m_hallActive) {
+  // Machine is initialized when carriage is detected
+  if (m_carriage != NoCarriage) {
     _ready = true;
   }
 #endif  // DBG_NOMACHINE


### PR DESCRIPTION
Add support for G-carriage detection

For G-carriage, per brother doc, south-then-north transitions within 3 needles is detected (but not the other way around), when only one transition is detected (within 3 needles) then K or L is reported.

Tested on KH910 => couldn't test RHS detection due to the HW bug (and  commented out L75-L81 as a consequence but it should just work as well)