### PR TITLE
Ignore empty SLIP packets

### DIFF
--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -122,6 +122,11 @@ void Com::send_indState(Carriage_t carriage, uint8_t position,
  * \param size The number of bytes in the data buffer.
  */
 void Com::onPacketReceived(const uint8_t *buffer, size_t size) {
+  // Ignore empty packets (sliplib in Python emits END bytes at the start of packets)
+  if (size <= 0) {
+    return;
+  }
+
   switch (buffer[0]) {
   case static_cast<uint8_t>(AYAB_API::reqInit):
     h_reqInit(buffer, size);

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -263,6 +263,13 @@ TEST_F(ComTest, test_unrecognized) {
   com->onPacketReceived(buffer, sizeof(buffer));
 }
 
+TEST_F(ComTest, test_empty_message_is_ignored) {
+  uint8_t buffer[] = {static_cast<uint8_t>(AYAB_API::reqInfo)};
+  EXPECT_CALL(*serialMock, write(_, _)).Times(0);
+
+  com->onPacketReceived(buffer, 0);
+}
+
 TEST_F(ComTest, test_cnfline_kh910) {
   // dummy pattern
   uint8_t pattern[] = {1};


### PR DESCRIPTION
## Issue

While analyzing the serial traffic between the AYAB desktop app and the firmware, I was surprised to find that the Arduino regularly received empty SLIP packets, i.e. two `0xC0` (the SLIP packet end marker) bytes following each other. It turns out a common practice when implementing SLIP is to start (not just end) each packet with an end marker, in order to flush any garbage that may have been received prior to the packet. And `sliplib` in Python follows that practice, see https://github.com/rhjdjong/SlipLib/issues/45

On the Arduino side, the `PacketSerial` library does nothing to filter out these empty packets, so `Com::onPacketReceived` is called with a `size` of `0`. It then proceeds to look at the first byte of the buffer, which is out of bounds.

I couldn't reproduce an actual issue caused by this out-of-bounds access: in my testing, the first byte always ended up being `0xEA` which doesn't match any AYAB command, so it was safely ignored.

Still, it seems like it would be best to avoid reading uninitialized memory.

## Proposed solution

Add a check for empty packets at the start of `Com::onPacketReceived`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of empty packets to prevent processing of invalid data, enhancing the robustness of the packet processing system.
- **Tests**
	- Added a new unit test to ensure that empty messages are ignored and do not trigger write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->