### PR TITLE
Add optional stack overflow checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ To set up a working development environment follow these steps:
     Please [download the PlatformIO plugin](https://platformio.org/install/integration) for your favorite IDE, i.e. VSCode.
     Then, open the ayab-firmware project and hit Build and/or Upload to compile and upload to hardware.
 
+### Enabling stack overflow detection
+
+You can build a version of the firmware that will try to detect memory corruption due to stack overflow as soon as it happens.
+
+ 1. Open the `platformio.ini` file and uncomment the line that contains `-DENABLE_STACK_CANARY=1`
+
+ 2. Build and upload the firmware to your Arduino board
+
+ 3. Use the firmware as you would normally. If at any point the firmware stops responding to the AYAB desktop application, and you see the yellow LED flashing repeatedly, congratulations: you have hit a stack overflow condition. Please open an issue in this repository describing what you were doing when the problem occurred.
+
 ### Unit tests and code analysis
 
  1. Install the [Arduino.mk](https://github.com/sudar/Arduino-Makefile) package and setup environment variables.

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,5 @@ extra_scripts =
 [env:uno]
 platform = atmelavr
 board = uno
+build_flags =
+;    -DENABLE_STACK_CANARY=1

--- a/src/ayab/main.cpp
+++ b/src/ayab/main.cpp
@@ -55,7 +55,47 @@ TesterInterface    *GlobalTester::m_instance    = &_Tester;
 /*!
  * Setup - do once before going to the main loop.
  */
+#if ENABLE_STACK_CANARY
+
+#define STACK_CANARY_VALUE 0x55aa
+
+uint16_t *stackCanary = nullptr;
+
+void stackCanarySetup() {
+  // Allocate a word on the top of the heap. If the stack, which grows
+  // downward from the top of memory, overflows, this value will likely
+  // be overwritten.
+  stackCanary = new uint16_t(STACK_CANARY_VALUE);
+}
+
+void stackCanaryCheck() {
+  if (*stackCanary != STACK_CANARY_VALUE) {
+    // Memory has been corrupted. Enter "panic" mode: flash LEDs rapidly,
+    // and output "PANIC" on the serial port repeatedly.
+    while(true) {
+      Serial.print("PANIC");
+      pinMode(LED_BUILTIN, OUTPUT);
+      pinMode(LED_PIN_B, OUTPUT);
+      digitalWrite(LED_PIN_B, LOW);
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(200);
+      digitalWrite(LED_PIN_B, HIGH);
+      digitalWrite(LED_BUILTIN, HIGH);
+      delay(200);
+    }
+  } 
+}
+
+#else // ENABLE_STACK_CANARY
+
+#define stackCanarySetup()
+#define stackCanaryCheck()
+
+#endif // ENABLE_STACK_CANARY
+
 void setup() {
+  stackCanarySetup();
+
   GlobalBeeper::init(false);
   GlobalCom::init();
   GlobalFsm::init();
@@ -67,6 +107,8 @@ void setup() {
  * Main Loop - repeat forever.
  */
 void loop() {
+  stackCanaryCheck();
+
   GlobalFsm::dispatch();
   if (GlobalBeeper::enabled()) {
     GlobalBeeper::schedule();


### PR DESCRIPTION
While working on getting the hardware test mode to work, I encountered some erratic behaviours (like the Arduino spontaneously resetting) that made me suspect memory corruption. As the Arduino UNO has only 2048 bytes of RAM, it is very easy to exhaust the available memory in a way that is not detected at compilation time, but results in the program stack (which grows down from the top of memory) overwriting the heap and static data areas.

So I added some code to try to detect such a situation: with the `ENABLE_STACK_CANARY` #define, a "stack canary" is enabled which will detect the stack growing past the top of the heap and enter a "panic" mode to show the problem occurring (by flashing a LED). The canary does consume a few bytes of RAM, so in theory it could itself be the proverbial needle that breaks the camel's back, but if these few bytes are the only margin of safety, a problem probably needs to be addressed.

Note that in this PR the canary is disabled by default (in `platformio.ini`), because it actual triggers in normal knitting use, illustrating that there is a problem that needs to be addressed. I have an upcoming PR that offers improvements on this front.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a stack canary mechanism to enhance memory safety, detecting stack buffer overflows.
	- Added functions to set up and check the stack canary, improving overall system robustness.

- **Documentation**
	- Updated the README.md with instructions for enabling stack overflow detection, providing users with clear steps to enhance firmware reliability.

- **Configuration Changes**
	- Updated build configuration to include an option for enabling the stack canary, increasing security potential (currently commented out).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->