### PR TITLE
Allocate class instances statically

### DIFF
--- a/src/ayab/main.cpp
+++ b/src/ayab/main.cpp
@@ -32,28 +32,25 @@
 #include "solenoids.h"
 #include "tester.h"
 
-// Global definitions: references elsewhere must use `extern`.
-// Each of the following is a pointer to a singleton class
-// containing static methods.
-constexpr GlobalBeeper    *beeper;
-constexpr GlobalCom       *com;
-constexpr GlobalEncoders  *encoders;
-constexpr GlobalFsm       *fsm;
-constexpr GlobalKnitter   *knitter;
-constexpr GlobalSolenoids *solenoids;
-constexpr GlobalTester    *tester;
-
 // Initialize static members.
 // Each singleton class contains a pointer to a static instance
 // that implements a public interface. When testing, a pointer
 // to an instance of a mock class can be substituted.
-BeeperInterface    *GlobalBeeper::m_instance    = new Beeper();
-ComInterface       *GlobalCom::m_instance       = new Com();
-EncodersInterface  *GlobalEncoders::m_instance  = new Encoders();
-FsmInterface       *GlobalFsm::m_instance       = new Fsm();
-KnitterInterface   *GlobalKnitter::m_instance   = new Knitter();
-SolenoidsInterface *GlobalSolenoids::m_instance = new Solenoids();
-TesterInterface    *GlobalTester::m_instance    = new Tester();
+Beeper _Beeper;
+Com _Com;
+Encoders _Encoders;
+Fsm _Fsm;
+Knitter _Knitter;
+Solenoids _Solenoids;
+Tester _Tester;
+
+BeeperInterface    *GlobalBeeper::m_instance    = &_Beeper;
+ComInterface       *GlobalCom::m_instance       = &_Com;
+EncodersInterface  *GlobalEncoders::m_instance  = &_Encoders;
+FsmInterface       *GlobalFsm::m_instance       = &_Fsm;
+KnitterInterface   *GlobalKnitter::m_instance   = &_Knitter;
+SolenoidsInterface *GlobalSolenoids::m_instance = &_Solenoids;
+TesterInterface    *GlobalTester::m_instance    = &_Tester;
 
 /*!
  * Setup - do once before going to the main loop.


### PR DESCRIPTION
## Issue

The classes that make up the AYAB firmware are currently dynamically allocated with `new` at the top level of `main.cpp`:

https://github.com/AllYarnsAreBeautiful/ayab-firmware/blob/e960ad4d9cd86daa4b3abbafad90de51ad102da5/src/ayab/main.cpp#L50-L56

Since these objects are allocated at the start of the program and never freed, there is no advantage to having them dynamically allocated. On the other hand, there are disadvantages:
- dynamically allocated objects can use a few more bytes for the memory allocator's bookkeeping;
- the memory used by these objects is not counted in the PlatformIO builder's statistics of RAM usage, that are printed after every build.

That last point in particular can hide the fact that the memory requirements for the firmware exceed the target microcontroller's RAM size (2048 bytes for the Atmega328p on an Arduino Uno).

## Proposed solution

This PR replaces the use of `new` by the creation of statically allocated instances. The global pointers are then initialized to point to these instances.

Before this PR, here is what the output of the PlatformIO builder looks like:

```
RAM:   [======    ]  60.2% (used 1232 bytes from 2048 bytes)
```

Which looks reasonable. But after including the firmware's main objects in the statically allocated area as this PR does, here is the output:

```
RAM:   [========= ]  91.3% (used 1869 bytes from 2048 bytes)
```

Revealing that the memory actually available for the stack is much less than was suggested by the earlier output, causing issues like #190.

The memory saved here seems to fix #190 partially. At least, even with stack overflow detection enabled, the firmware can now survive `reqInit` and even knitting, from my quick test.

Note that this PR also deletes a series of uninitialized constant pointers that appear to have been remains from an earlier attempt at these global pointers.