### PR TITLE
Remove non-const char overload of Com::sendMsg

### DIFF
--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -73,10 +73,7 @@ void Com::sendMsg(AYAB_API_t id, const char *msg) {
   while (*msg) {
     msgBuffer[length++] = static_cast<uint8_t>(*msg++);
   }
-  m_packetSerial.send(msgBuffer, length);
-}
-void Com::sendMsg(AYAB_API_t id, char *msg) {
-  sendMsg(id, static_cast<const char *>(msg));
+  send(msgBuffer, length);
 }
 
 /*!

--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -87,7 +87,6 @@ public:
   virtual void update() = 0;
   virtual void send(uint8_t *payload, size_t length) const = 0;
   virtual void sendMsg(AYAB_API_t id, const char *msg) = 0;
-  virtual void sendMsg(AYAB_API_t id, char *msg) = 0;
   virtual void send_reqLine(const uint8_t lineNumber,
                             Err_t error = ErrorCode::success) const = 0;
   virtual void send_indState(Carriage_t carriage, uint8_t position,
@@ -113,7 +112,6 @@ public:
   static void update();
   static void send(uint8_t *payload, size_t length);
   static void sendMsg(AYAB_API_t id, const char *msg);
-  static void sendMsg(AYAB_API_t id, char *msg);
   static void send_reqLine(const uint8_t lineNumber, Err_t error = ErrorCode::success);
   static void send_indState(Carriage_t carriage, uint8_t position,
                              Err_t error = ErrorCode::success);
@@ -129,7 +127,6 @@ public:
   void update() final;
   void send(uint8_t *payload, size_t length) const final;
   void sendMsg(AYAB_API_t id, const char *msg) final;
-  void sendMsg(AYAB_API_t id, char *msg) final;
   void send_reqLine(const uint8_t lineNumber, Err_t error = ErrorCode::success) const final;
   void send_indState(Carriage_t carriage, uint8_t position,
                              Err_t error = ErrorCode::success) const final;

--- a/src/ayab/global_com.cpp
+++ b/src/ayab/global_com.cpp
@@ -44,10 +44,6 @@ void GlobalCom::sendMsg(AYAB_API_t id, const char *msg) {
   m_instance->sendMsg(id, msg);
 }
 
-void GlobalCom::sendMsg(AYAB_API_t id, char *msg) {
-  m_instance->sendMsg(id, msg);
-}
-
 // GCOVR_EXCL_START
 void GlobalCom::onPacketReceived(const uint8_t *buffer, size_t size) {
   m_instance->onPacketReceived(buffer, size);

--- a/test/mocks/com_mock.cpp
+++ b/test/mocks/com_mock.cpp
@@ -60,11 +60,6 @@ void Com::sendMsg(AYAB_API_t id, const char *msg) {
   gComMock->sendMsg(id, msg);
 }
 
-void Com::sendMsg(AYAB_API_t id, char *msg) {
-  assert(gComMock != nullptr);
-  gComMock->sendMsg(id, msg);
-}
-
 void Com::send_reqLine(const uint8_t lineNumber, Err_t error) const {
   assert(gComMock != nullptr);
   gComMock->send_reqLine(lineNumber, error);

--- a/test/mocks/com_mock.h
+++ b/test/mocks/com_mock.h
@@ -34,7 +34,6 @@ public:
   MOCK_METHOD0(update, void());
   MOCK_CONST_METHOD2(send, void(uint8_t *payload, size_t length));
   MOCK_METHOD2(sendMsg, void(AYAB_API_t id, const char *msg));
-  MOCK_METHOD2(sendMsg, void(AYAB_API_t id, char *msg));
   MOCK_CONST_METHOD2(send_reqLine, void(const uint8_t lineNumber, Err_t error));
   MOCK_CONST_METHOD3(send_indState, void(Carriage_t carriage, uint8_t position,
                                    Err_t error));


### PR DESCRIPTION
A little bit of code cleanup: casting `char *` to `const char *` is a safe conversion that the compiler performs automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `sendMsg` method across multiple classes to accept only `const char*`, enhancing safety and clarity in message handling.
- **Bug Fixes**
	- Removed potential issues associated with modifying message content during transmission by enforcing const-correctness in the `sendMsg` method.
- **Tests**
	- Adjusted mock implementations to reflect changes in the `sendMsg` method, ensuring consistency in testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->