### PR TITLE
com: shrink send/receive buffers from 256 to 64 bytes

### DIFF
--- a/src/ayab/com.h
+++ b/src/ayab/com.h
@@ -44,7 +44,7 @@ constexpr uint8_t API_VERSION = 6U;
 constexpr uint32_t SERIAL_BAUDRATE = 115200U;
 
 constexpr uint8_t MAX_LINE_BUFFER_LEN = 25U;
-constexpr uint8_t MAX_MSG_BUFFER_LEN = 255U;
+constexpr uint8_t MAX_MSG_BUFFER_LEN = 64U;
 
 enum class AYAB_API : unsigned char {
   reqStart = 0x01,
@@ -133,7 +133,7 @@ public:
   void onPacketReceived(const uint8_t *buffer, size_t size) final;
 
 private:
-  SLIPPacketSerial m_packetSerial;
+  PacketSerial_<SLIP, SLIP::END, MAX_MSG_BUFFER_LEN> m_packetSerial;
   uint8_t lineBuffer[MAX_LINE_BUFFER_LEN] = {0};
   uint8_t msgBuffer[MAX_MSG_BUFFER_LEN] = {0};
 


### PR DESCRIPTION
## Issue

As shown in #191 the memory usage of the firmware needs to be brought under control. A significant contributor to the allocated RAM is the set of message buffers used by the serial communication layer.

## Proposed solution

The largest message that is generated by the current protocol is a `cnfLine` containing 25 bytes of pattern, plus 5 bytes of other data. Even assuming a worst case of having to SLIP-escape all the bytes, this fits in a 64-byte buffer.

This PR therefore reduces both the outgoing message buffer (`Com::msgBuffer`) and the incoming message buffer in the `PacketSerial` instance to 64 bytes each.

If the objects are statically alllocated as proposed in #191 , it can be seen that the memory used goes from `91.3% (used 1869 bytes from 2048 bytes)` to `72.5% (used 1485 bytes from 2048 bytes)` with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the maximum message buffer size for improved performance and memory management.
	- Enhanced packet handling mechanism with a new templated serial class for better resource control.

These changes aim to optimize communication within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->