### PR TITLE
Remove 2-second delay when starting to knit

### DIFF
--- a/src/ayab/board.h
+++ b/src/ayab/board.h
@@ -47,9 +47,6 @@ constexpr uint8_t DBG_BTN_PIN = 7; // DEBUG BUTTON
 constexpr uint8_t I2Caddr_sol1_8 = 0x0U;  ///< I2C Address of solenoids 1 - 8
 constexpr uint8_t I2Caddr_sol9_16 = 0x1U; ///< I2C Address of solenoids 9 - 16
 
-// TODO(Who?): Optimize Delay for various Arduino Models
-constexpr uint16_t START_KNITTING_DELAY = 2000U; // ms
-
 // Determine board type
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
 // Arduino Uno

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -239,8 +239,6 @@ bool Knitter::isReady() {
 void Knitter::knit() {
   if (m_firstRun) {
     m_firstRun = false;
-    // TODO(who?): optimize delay for various Arduino models
-    delay(START_KNITTING_DELAY);
     GlobalBeeper::finishedLine();
     ++m_currentLineNumber;
     reqLine(m_currentLineNumber);

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -215,7 +215,6 @@ protected:
   }
 
   void expect_first_knit() {
-    EXPECT_CALL(*arduinoMock, delay(START_KNITTING_DELAY));
     EXPECT_CALL(*beeperMock, finishedLine);
     expect_reqLine();
   }

--- a/test/test_knitter.cpp
+++ b/test/test_knitter.cpp
@@ -253,7 +253,6 @@ protected:
   }
 
   void expect_first_knit() {
-    EXPECT_CALL(*arduinoMock, delay(START_KNITTING_DELAY));
     EXPECT_CALL(*beeperMock, finishedLine);
     expect_reqLine();
   }


### PR DESCRIPTION
## Issue

As recalled in #185, the firmware currently takes a 2-second nap when entering state `OpState::knit`, i.e. just after the carriage has passed either turn mark (Hall sensors) going towards the center of the bed: https://github.com/AllYarnsAreBeautiful/ayab-firmware/blob/25aa0472082945890e24e65589516dca30d08f0b/src/ayab/knitter.cpp#L243

Users have long been [instructed](https://github.com/AllYarnsAreBeautiful/ayab-manual/blob/a0cf63b1029a3b0935f30968d3f91bedb83f90cc/docs/how_to_knit/basics.md?plain=1#L24-L26) to respect this pause, whose end is signaled by a "triple-beep", before carrying on:
> 8. Move the carriage so the magnet on the back of the carriage crosses the left turn mark, and STOP.
> 9. **IMPORTANT!!!** Wait 2 or 3 seconds, there will be a "triple-beep"
> 10. Continue across the row. After you pass the end of the selected needles, it should beep.

However, the original reason for the pause is unclear. Apparently, the delay was necessary to make sure the first row was "fully available". Perhaps the serial communication (which used a different framing mechanism in the initial versions of AYAB) was somehow less efficient on the desktop side, so that forcing the user to wait could give some time for the desktop app to fill the Arduino's incoming serial buffer with the first row's contents. Although even this seems unlikely, since the firmware does not request the first row's contents until _after_ the two-second pause.

In any case, because this pause is implemented not just as a suggestion to the user to slow down (i.e. the firmware could instead try to get ready as fast as possible, then beep for the user to continue), but as actual downtime during which the firmware is unresponsive, it becomes in itself the most likely cause for incorrect behavior when the pause is not respected by the user (see https://github.com/AllYarnsAreBeautiful/ayab-firmware/issues/185#issuecomment-2067860796).

## Proposed solution

A [change](https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/679) was recently merged into `ayab-desktop` that reduces the latency of the serial communications between desktop app and firmware. With this change in place, it is now even unlikelier than before that the firmware and desktop app could take more than a tenth of a second to exchange all the information needed to start knitting.

We agreed on Discord that at this point, the simplest course of action would be to try removing the start delay entirely, and see if anything breaks.

Hence this simple PR, from which I created a build of the desktop app that embeds a [firmware binary](https://github.com/jonathanperret/ayab-firmware/releases/tag/0.99.0-20240725-no-start-delay) that has the delay removed. This build can be downloaded here: https://github.com/jonathanperret/ayab-desktop/releases/tag/0.99.0-20240725-no-start-delay . Make sure to use the "Load firmware" menu item to flash the patched firmware before testing. For testing convenience, this app build includes both the current (`0.99.0-rc3`) firmware and the patched one (`0.99.0-20240725-no-start-delay`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved responsiveness of the knitting process by removing unnecessary delay during the initial operation.
  
- **Bug Fixes**
  - Streamlined test cases by removing outdated expectations related to the knitting delay, enhancing test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->