### PR TITLE
Include full firmware version in test mode welcome message

### DIFF
--- a/src/ayab/tester.cpp
+++ b/src/ayab/tester.cpp
@@ -203,10 +203,9 @@ void Tester::encoderAChange() {
 void Tester::setUp() {
   // Print welcome message
   GlobalCom::sendMsg(AYAB_API::testRes, "AYAB Hardware Test, ");
-  snprintf(buf, BUFFER_LEN, "Firmware v%hhu", FW_VERSION_MAJ);
+  snprintf(buf, BUFFER_LEN, "Firmware v%hhu.%hhu.%hhu", FW_VERSION_MAJ, FW_VERSION_MIN, FW_VERSION_PATCH);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
-  snprintf(buf, BUFFER_LEN, ".%hhu", FW_VERSION_MIN);
-  GlobalCom::sendMsg(AYAB_API::testRes, buf);
+  GlobalCom::sendMsg(AYAB_API::testRes, FW_VERSION_SUFFIX);
   snprintf(buf, BUFFER_LEN, " API v%hhu\n\n", API_VERSION);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
   helpCmd();


### PR DESCRIPTION
Test mode will likely the easiest way for a user to determine which firmware version their machine is running; as we head into wider testing rounds, it seems quite valuable to make this information easily available.

The current firmware's output (assuming a desktop app that includes https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/693), as displayed in the hardware test dialog, starts with:

```
AYAB Hardware Test, Firmware v0.99 API v6
```

With this PR, the firmware gives a more detailed version designator:

```
AYAB Hardware Test, Firmware v0.99.0rc3-8-ge9770c8 API v6
```
