### PR TITLE
tester: enable beeper so that beep command does something

### DIFF
--- a/src/ayab/global_tester.cpp
+++ b/src/ayab/global_tester.cpp
@@ -79,7 +79,7 @@ void GlobalTester::quitCmd() {
 }
 
 #ifndef AYAB_TESTS
-void GlobalTester::encoderAChange() {
-  m_instance->encoderAChange();
+void GlobalTester::encoderChange() {
+  m_instance->encoderChange();
 }
 #endif // AYAB_TESTS

--- a/src/ayab/tester.cpp
+++ b/src/ayab/tester.cpp
@@ -223,6 +223,9 @@ void Tester::setUp() {
   m_autoTestOn = false;
   m_lastTime = millis();
   m_timerEventOdd = false;
+
+  // Enable beeper so that it can be tested
+  GlobalBeeper::init(true);
 }
 
 /*!

--- a/src/ayab/tester.cpp
+++ b/src/ayab/tester.cpp
@@ -155,8 +155,10 @@ void Tester::stopCmd() {
  * \brief Quit command handler.
  */
 void Tester::quitCmd() {
-  GlobalFsm::setState(OpState::init);
-  GlobalKnitter::setUpInterrupt();
+  detachInterrupt(digitalPinToInterrupt(ENC_PIN_A));
+  detachInterrupt(digitalPinToInterrupt(ENC_PIN_B));
+
+  GlobalFsm::setState(OpState::wait_for_machine);
 }
 
 /*!
@@ -190,8 +192,9 @@ void Tester::loop() {
 /*!
  * \brief Interrupt service routine for encoder A.
  */
-void Tester::encoderAChange() {
-  beep();
+void Tester::encoderChange() {
+  digitalWrite(LED_PIN_A, digitalRead(ENC_PIN_A));
+  digitalWrite(LED_PIN_B, digitalRead(ENC_PIN_B));
 }
 #endif // AYAB_TESTS
 
@@ -210,13 +213,10 @@ void Tester::setUp() {
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
   helpCmd();
 
-  // attach interrupt for ENC_PIN_A(=2), interrupt #0
-  detachInterrupt(digitalPinToInterrupt(ENC_PIN_A));
 #ifndef AYAB_TESTS
-  // Attaching ENC_PIN_A, Interrupt #0
-  // This interrupt cannot be enabled until
-  // the machine type has been validated.
-  attachInterrupt(digitalPinToInterrupt(ENC_PIN_A), GlobalTester::encoderAChange, RISING);
+  // Attach interrupts for both encoder pins
+  attachInterrupt(digitalPinToInterrupt(ENC_PIN_A), GlobalTester::encoderChange, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(ENC_PIN_B), GlobalTester::encoderChange, CHANGE);
 #endif // AYAB_TESTS
 
   m_autoReadOn = false;

--- a/src/ayab/tester.h
+++ b/src/ayab/tester.h
@@ -51,7 +51,7 @@ public:
   virtual void stopCmd() = 0;
   virtual void quitCmd() = 0;
 #ifndef AYAB_TESTS
-  virtual void encoderAChange();
+  virtual void encoderChange();
 #endif
 };
 
@@ -84,7 +84,7 @@ public:
   static void stopCmd();
   static void quitCmd();
 #ifndef AYAB_TESTS
-  static void encoderAChange();
+  static void encoderChange();
 #endif
 };
 
@@ -104,7 +104,7 @@ public:
   void stopCmd() final;
   void quitCmd() final;
 #ifndef AYAB_TESTS
-  void encoderAChange() final;
+  void encoderChange() final;
 #endif
 
 private:

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -249,12 +249,10 @@ TEST_F(ComTest, test_stopCmd) {
 
 TEST_F(ComTest, test_quitCmd) {
   uint8_t buffer[] = {static_cast<uint8_t>(AYAB_API::quitCmd)};
-  EXPECT_CALL(*knitterMock, setUpInterrupt);
-  EXPECT_CALL(*fsmMock, setState(OpState::init));
+  EXPECT_CALL(*fsmMock, setState(OpState::wait_for_machine));
   com->onPacketReceived(buffer, sizeof(buffer));
 
   // test expectations without destroying instance
-  ASSERT_TRUE(Mock::VerifyAndClear(knitterMock));
   ASSERT_TRUE(Mock::VerifyAndClear(fsmMock));
 }
 

--- a/test/test_tester.cpp
+++ b/test/test_tester.cpp
@@ -194,12 +194,10 @@ TEST_F(TesterTest, test_autoTestCmd) {
 }
 
 TEST_F(TesterTest, test_quitCmd) {
-  EXPECT_CALL(*knitterMock, setUpInterrupt);
-  EXPECT_CALL(*fsmMock, setState(OpState::init));
+  EXPECT_CALL(*fsmMock, setState(OpState::wait_for_machine));
   tester->quitCmd();
 
   // test expectations without destroying instance
-  ASSERT_TRUE(Mock::VerifyAndClear(knitterMock));
   ASSERT_TRUE(Mock::VerifyAndClear(fsmMock));
 }
 


### PR DESCRIPTION
Fixes #198, simply by enabling the beeper when entering test mode.

As I was testing this, I discovered the tester installed an ISR on the A encoder pin that triggered a beep on every rising edge. As this did not seem usable in practice, I removed the beep there and changed the ISR to instead reflect the state of encoder pins A and B on the LEDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced command handling and interrupt management for improved system responsiveness.
- **Bug Fixes**
  - Updated expected state transitions for the quit command to align with new operational logic.
- **Refactor**
  - Standardized method naming for improved clarity and consistency across related classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->