### PR TITLE
Tester: don't send empty message for empty version suffix, and add `-` in front of version suffix

### DIFF
--- a/src/ayab/tester.cpp
+++ b/src/ayab/tester.cpp
@@ -208,7 +208,10 @@ void Tester::setUp() {
   GlobalCom::sendMsg(AYAB_API::testRes, "AYAB Hardware Test, ");
   snprintf(buf, BUFFER_LEN, "Firmware v%hhu.%hhu.%hhu", FW_VERSION_MAJ, FW_VERSION_MIN, FW_VERSION_PATCH);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
-  GlobalCom::sendMsg(AYAB_API::testRes, FW_VERSION_SUFFIX);
+  if (*FW_VERSION_SUFFIX != '\0') {
+    snprintf(buf, BUFFER_LEN, "-%s", FW_VERSION_SUFFIX);
+    GlobalCom::sendMsg(AYAB_API::testRes, buf);
+  }
   snprintf(buf, BUFFER_LEN, " API v%hhu\n\n", API_VERSION);
   GlobalCom::sendMsg(AYAB_API::testRes, buf);
   helpCmd();


### PR DESCRIPTION
 The desktop app currently crashes when handling a testRes message with an empty string (see https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/701).

That bug should be fixed over there, but it turns out there's a bug in the firmware as well (that I introduced in https://github.com/AllYarnsAreBeautiful/ayab-firmware/pull/195), in that the suffix is not prefixed by a `-` as it should be.

Adding this prefix, and making sure we don't send anything if there is no suffix, fixes that and "accidentally" works around the desktop bug.

## How to test

1. Upload a firmware with a non-suffixed tag:
```
$ git tag 1.2.3
$ pio run -t upload
$ git tag -d 1.2.3
```
2. Run `ayab-desktop` and open the Hardware test dialog (without this PR, the dialog fails to open).
3. Check that the dialog opens and the displayed version is correct.
4. Upload a firmware with a suffixed tag:
```
$ git tag 1.2.3-beta456
$ pio run -t upload
$ git tag -d 1.2.3-beta456
```
5. Run `ayab-desktop` and open the Hardware test dialog.
6. Check that the dialog opens and the displayed version is correct (without this PR, the version is missing its separator, e.g. `1.2.3beta456`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved message accuracy by conditionally including the `FW_VERSION_SUFFIX` in the output, ensuring that only non-empty values are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->