### PR TITLE
Fix clunking sound from solenoids (#15)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "libraries/PacketSerial"]
 	path = lib/PacketSerial
 	url = https://github.com/bakercp/PacketSerial.git
-[submodule "libraries/Adafruit_MCP23008"]
-	url = https://github.com/adafruit/Adafruit-MCP23008-library.git
-	path = lib/Adafruit_MCP23008

--- a/src/ayab/solenoids.h
+++ b/src/ayab/solenoids.h
@@ -27,7 +27,6 @@
 #include "board.h"
 #include "encoders.h"
 #include <Arduino.h>
-#include <Adafruit_MCP23008.h>
 #include <Wire.h>
 
 // Different machines have a different number of solenoids.
@@ -81,11 +80,10 @@ public:
   void setSolenoids(uint16_t state) final;
 
 private:
-  uint16_t solenoidState = 0x0000U;
-  void write(uint16_t state);
+  uint16_t solenoidState = 0xffffU;
 
-  Adafruit_MCP23008 mcp_0 = Adafruit_MCP23008();
-  Adafruit_MCP23008 mcp_1 = Adafruit_MCP23008();
+  void writeGPIO(uint16_t state);
+  void writeRegister(uint8_t i2caddr, uint8_t reg, uint8_t value);
 };
 
 #endif // SOLENOIDS_H_

--- a/static_analysis.sh
+++ b/static_analysis.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-clang-tidy src/ayab/$1.cpp --fix -- -isystem /usr/share/arduino/hardware/arduino/cores/arduino/ -isystem /usr/lib/avr/include/ -isystem /usr/share/arduino/hardware/arduino/variants/standard -isystem libraries/Adafruit_MCP23008/ -isystem /usr/share/arduino/libraries/Wire/ -isystem libraries/PacketSerial/src/ -DCLANG_TIDY "${@:2}"
+clang-tidy src/ayab/$1.cpp --fix -- -isystem /usr/share/arduino/hardware/arduino/cores/arduino/ -isystem /usr/lib/avr/include/ -isystem /usr/share/arduino/hardware/arduino/variants/standard -isystem /usr/share/arduino/libraries/Wire/ -isystem libraries/PacketSerial/src/ -DCLANG_TIDY "${@:2}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,9 +31,6 @@ set(COMMON_INCLUDES
     ${SOURCE_DIRECTORY}
     ${LIBRARY_DIRECTORY}/PacketSerial/src
     )
-set(EXTERNAL_LIB_INCLUDES
-    ${LIBRARY_DIRECTORY}/Adafruit_MCP23008
-    )
 set(COMMON_SOURCES
     ${PROJECT_SOURCE_DIR}/test_boards.cpp
 
@@ -85,20 +82,12 @@ set(COMMON_LINKER_FLAGS
     ${CMAKE_THREAD_LIBS_INIT}
     -lgcov
     )
-set(HARD_I2C_LIB
-    ${LIBRARY_DIRECTORY}/Adafruit_MCP23008/Adafruit_MCP23008.cpp
-    )
 function(add_board board)
     set(processor # uno
         __AVR_ATmega168__
         )
-    set(I2C_LIB
-        ${HARD_I2C_LIB}
-        )
     add_executable(${PROJECT_NAME}_${board}
         ${COMMON_SOURCES}
-        # External libraries
-        ${I2C_LIB}
         )
     target_include_directories(${PROJECT_NAME}_${board}
         PRIVATE

--- a/test/test_solenoids.cpp
+++ b/test/test_solenoids.cpp
@@ -50,7 +50,7 @@ TEST_F(SolenoidsTest, test_construct) {
 
 TEST_F(SolenoidsTest, test_init) {
   solenoids->init();
-  ASSERT_TRUE(solenoids->solenoidState == 0U);
+  ASSERT_TRUE(solenoids->solenoidState == 0xffffU);
 }
 
 TEST_F(SolenoidsTest, test_setSolenoid1) {


### PR DESCRIPTION
## Problem

Fixes #15.

## Proposed solution

The "clunking" sound that is occasionnally heard when using AYAB is caused by all solenoid armatures being released simultaneously when all solenoids are turned off.

This does not happen with Brother electronics because they default to keeping solenoids on.

This PR changes AYAB's behavior to match that behavior of the Brother electronics.

Note that this required abandoning the third-party library used to drive the I/O expanders (`Adafruit_MCP23008`) since
part of its non-skippable initialization code was forcing all outputs to off. It turns out the amount of code needed to directly drive the MCP23008 expanders using the Arduino Wire library is only a dozen lines of code anyway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Removed dependency on the Adafruit MCP23008 library, streamlining solenoid control.
  
- **Bug Fixes**
	- Updated solenoid initialization to ensure all solenoids remain ON by default, preventing noise during operation.
  
- **Tests**
	- Adjusted initial state assertion in solenoid tests to reflect new default state of `0xffffU`.

- **Chores**
	- Cleaned up build configuration by removing unused library references from test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->