### PR TITLE
Fix carriage detection on the right

### DIFF
--- a/src/ayab/encoders.cpp
+++ b/src/ayab/encoders.cpp
@@ -193,27 +193,30 @@ void Encoders::encA_rising() {
       return;
     }
 
-    // For KH-270, if the carriage is already set, ignore the rest.
-    if (Machine_t::Kh270 == m_machineType && Carriage_t::Knit == m_carriage) {
-      return;
-    }
+    // The KH270 carriage also has two magnets, but:
+    // - the sensors and magnets are set up such that the carriage center
+    //   is in front of the first/last needle when the carriage's outermost
+    //   magnet is in front of the sensor;
+    // - we will always see the outermost magnet last and reset the position
+    //   to a correct value, so it's not a problem if we detect the innermost
+    //   first, even though that gives us a wrong position for a few needles
+    //   (since we're not selecting anything at that point this has no impact)
+    // So there's no need to special-case position detection for the KH270 carriage.
 
-    // Only set the belt shift the first time a magnet passes the turn mark.
-    // Headed to the right.
-    if (!m_passedLeft && Direction_t::Right == m_direction) {
-      // Belt shift signal only decided in front of hall sensor
-      m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Shifted : BeltShift::Regular;
-      m_passedLeft = true;
+    // KH270 has no belt shift
+    if (m_machineType != Machine_t::Kh270) {
+      // Only set the belt shift the first time a magnet passes the turn mark.
+      // Headed to the right.
+      if (!m_passedLeft && Direction_t::Right == m_direction) {
+        // Belt shift signal only decided in front of hall sensor
+        m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Shifted : BeltShift::Regular;
+        m_passedLeft = true;
+      }
     }
 
     uint8_t start_position = END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)];
 
-    if (m_machineType == Machine_t::Kh270) {
-      m_carriage = Carriage_t::Knit;
-
-      // Assume the rightmost magnet was detected
-      start_position = start_position + MAGNET_DISTANCE_270;
-    } else if (m_carriage == Carriage_t::Lace &&
+    if (m_carriage == Carriage_t::Lace &&
                detected_carriage == Carriage_t::Knit &&
                m_position > start_position) {
       m_carriage = Carriage_t::Garter;
@@ -281,29 +284,32 @@ void Encoders::encA_falling() {
       return;
     }
 
-    // For KH-270, if the carriage is already set, ignore the rest.
-    if (Machine_t::Kh270 == m_machineType && Carriage_t::Knit == m_carriage) {
-      return;
-    }
+    // The KH270 carriage also has two magnets, but:
+    // - the sensors and magnets are set up such that the carriage center
+    //   is in front of the first/last needle when the carriage's outermost
+    //   magnet is in front of the sensor;
+    // - we will always see the outermost magnet last and reset the position
+    //   to a correct value, so it's not a problem if we detect the innermost
+    //   first, even though that gives us a wrong position for a few needles
+    //   (since we're not selecting anything at that point this has no impact)
+    // So there's no need to special-case position detection for the KH270 carriage.
 
-    // Only set the belt shift the first time a magnet passes the turn mark.
-    // Headed to the left.
-    if (!m_passedRight && Direction_t::Left == m_direction) {
-      // Belt shift signal only decided in front of hall sensor
-      m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Regular : BeltShift::Shifted;
-      m_passedRight = true;
+    // KH270 has no belt shift
+    if (m_machineType != Machine_t::Kh270) {
+      // Only set the belt shift the first time a magnet passes the turn mark.
+      // Headed to the left.
+      if (!m_passedRight && Direction_t::Left == m_direction) {
+        // Belt shift signal only decided in front of hall sensor
+        m_beltShift = digitalRead(ENC_PIN_C) != 0 ? BeltShift::Regular : BeltShift::Shifted;
+        m_passedRight = true;
 
-      // Shift doesn't need to be swapped for the g-carriage in this direction.
+        // Shift doesn't need to be swapped for the g-carriage in this direction.
+      }
     }
 
     uint8_t start_position = END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)];
 
-    if (m_machineType == Machine_t::Kh270) {
-      m_carriage = Carriage_t::Knit;
-
-      // Assume the leftmost magnet was detected
-      start_position = start_position; // FIXME
-    } else if (m_carriage == Carriage_t::Lace &&
+    if (m_carriage == Carriage_t::Lace &&
                detected_carriage == Carriage_t::Knit &&
                m_position < start_position) {
       m_carriage = Carriage_t::Garter;

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -81,19 +81,23 @@ constexpr uint8_t ALL_MAGNETS_CLEARED_RIGHT[NUM_MACHINES] = {199U, 199U, 130U};
 // If we didn't have it, we'd decide which carriage we had when the first magnet passed the sensor.
 // For the garter carriage we need to see both magnets.
 constexpr uint8_t GARTER_SLOP = 2U;
+// Spacing between a garter carriage's outer (L-carriage-like) magnets.
+// For consistency between a garter carriage starting on the left or the right,
+// we need to adjust the position by this distance when starting from the right.
+constexpr uint8_t GARTER_L_MAGNET_SPACING = 24U;
 
 constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
     // KH910
     {
         // K,   L,   G
         {42U, 32U, 32U}, // Left
-        {16U, 32U, 50U} // Right
+        {16U, 24U, 48U} // Right
     },
     // KH930
     {
         // K,   L,   G
         {42U, 32U, 32U}, // Left
-        {16U, 32U, 50U} // Right
+        {16U, 24U, 48U} // Right
     },
     // KH270
     {
@@ -108,7 +112,7 @@ constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
 //                                               KH910 KH930 KH270
 constexpr uint16_t FILTER_L_MIN[NUM_MACHINES] = { 200U, 200U, 200U};
 constexpr uint16_t FILTER_L_MAX[NUM_MACHINES] = { 600U, 600U, 600U};
-constexpr uint16_t FILTER_R_MIN[NUM_MACHINES] = { 200U,   0U,   0U};
+constexpr uint16_t FILTER_R_MIN[NUM_MACHINES] = { 200U, 200U, 200U};
 constexpr uint16_t FILTER_R_MAX[NUM_MACHINES] = {1023U, 600U, 600U};
 
 constexpr uint16_t SOLENOIDS_BITMASK = 0xFFFFU;
@@ -181,6 +185,7 @@ private:
   volatile BeltShift_t m_beltShift;
   volatile Carriage_t m_carriage;
   volatile Carriage_t m_previousDetectedCarriageLeft;
+  volatile Carriage_t m_previousDetectedCarriageRight;
   volatile Direction_t m_direction;
   volatile Direction_t m_hallActive;
   volatile uint8_t m_position;
@@ -189,6 +194,7 @@ private:
   volatile bool m_passedRight;
 
   Carriage_t detectCarriageLeft();
+  Carriage_t detectCarriageRight();
   void encA_rising();
   void encA_falling();
 };

--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -66,16 +66,16 @@ constexpr uint8_t END_OF_LINE_OFFSET_L[NUM_MACHINES] = {12U, 12U, 6U};
 constexpr uint8_t END_OF_LINE_OFFSET_R[NUM_MACHINES] = {12U, 12U, 6U};
 
 constexpr uint8_t END_LEFT[NUM_MACHINES] = {0U, 0U, 0U};
-constexpr uint8_t END_RIGHT[NUM_MACHINES] = {255U, 255U, 140U};
-constexpr uint8_t END_OFFSET[NUM_MACHINES] = {28U, 28U, 5U};
+constexpr uint8_t END_RIGHT[NUM_MACHINES] = {255U, 255U, 167U};
+constexpr uint8_t END_OFFSET[NUM_MACHINES] = {28U, 28U, 28U};
 
 // The following two arrays are created by combining, respectively,
 // the arrays END_LEFT and END_RIGHT with END_OFFSET
-constexpr uint8_t END_LEFT_PLUS_OFFSET[NUM_MACHINES] = {28U, 28U, 5U};
-constexpr uint8_t END_RIGHT_MINUS_OFFSET[NUM_MACHINES] = {227U, 227U, 135U};
+constexpr uint8_t END_LEFT_PLUS_OFFSET[NUM_MACHINES] = {28U, 28U, 28U};
+constexpr uint8_t END_RIGHT_MINUS_OFFSET[NUM_MACHINES] = {227U, 227U, 139U};
 
-constexpr uint8_t ALL_MAGNETS_CLEARED_LEFT[NUM_MACHINES] = {56U, 56U, 10U};
-constexpr uint8_t ALL_MAGNETS_CLEARED_RIGHT[NUM_MACHINES] = {199U, 199U, 130U};
+constexpr uint8_t ALL_MAGNETS_CLEARED_LEFT[NUM_MACHINES] = {56U, 56U, 38U};
+constexpr uint8_t ALL_MAGNETS_CLEARED_RIGHT[NUM_MACHINES] = {199U, 199U, 129U};
 
 // The garter slop is needed to determine whether or not we have a garter carriage.
 // If we didn't have it, we'd decide which carriage we had when the first magnet passed the sensor.
@@ -102,8 +102,8 @@ constexpr uint8_t START_OFFSET[NUM_MACHINES][NUM_DIRECTIONS][NUM_CARRIAGES] = {
     // KH270
     {
         // K
-        {28U, 0U, 0U}, // Left
-        {16U, 0U, 0U} // Right
+        {28U + 6U, 0U, 0U}, // Left
+        {28U - 6U, 0U, 0U} // Right
     }};
 
 // Should be calibrated to each device
@@ -116,8 +116,6 @@ constexpr uint16_t FILTER_R_MIN[NUM_MACHINES] = { 200U, 200U, 200U};
 constexpr uint16_t FILTER_R_MAX[NUM_MACHINES] = {1023U, 600U, 600U};
 
 constexpr uint16_t SOLENOIDS_BITMASK = 0xFFFFU;
-
-constexpr uint8_t MAGNET_DISTANCE_270 = 12U;
 
 /*!
  * \brief Encoder interface.

--- a/src/ayab/knitter.cpp
+++ b/src/ayab/knitter.cpp
@@ -76,6 +76,7 @@ void Knitter::init() {
   m_workedOnLine = false;
   m_lastHall = Direction_t::NoDirection;
   m_position = 0U;
+  m_carriage = Carriage_t::NoCarriage;
   m_hallActive = Direction_t::NoDirection;
   m_pixelToSet = 0;
 #ifdef DBG_NOMACHINE
@@ -216,10 +217,12 @@ bool Knitter::isReady() {
         (m_position > (END_LEFT_PLUS_OFFSET[static_cast<uint8_t>(m_machineType)] + GARTER_SLOP));
   bool passedRight = (Direction_t::Left == m_direction) && (Direction_t::Right == m_lastHall) &&
         (m_position < (END_RIGHT_MINUS_OFFSET[static_cast<uint8_t>(m_machineType)] - GARTER_SLOP));
-  // Machine is initialized when left Hall sensor is passed in Right direction
-  // New feature (August 2020): the machine is also initialized
-  // when the right Hall sensor is passed in Left direction.
-  if (passedLeft || passedRight) {
+  // Machine is initialized when the left Hall sensor is passed in Right
+  // direction, or the right Hall sensor is passed in Left direction. Or, as
+  // soon as we have detected a Garter carriage, because in that case we may
+  // need to start setting solenoids before the carriage center has crossed the
+  // turn mark.
+  if (passedLeft || passedRight || m_carriage == Carriage_t::Garter) {
 
 #endif // DBG_NOMACHINE
     GlobalSolenoids::setSolenoids(SOLENOIDS_BITMASK);

--- a/test/test_encoders.cpp
+++ b/test/test_encoders.cpp
@@ -37,11 +37,6 @@ protected:
   void SetUp() override {
     arduinoMock = arduinoMockInstance();
 
-    // No triggered sensor at init time
-    EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-        .WillOnce(Return(MID_SENSOR_VALUE))
-        .RetiresOnSaturation();
-    
     encoders->init(Machine_t::Kh910);
   }
 
@@ -74,7 +69,7 @@ TEST_F(EncodersTest, test_encA_rising_not_in_front) {
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
-  ASSERT_FALSE(encoders->getMachineType() == Machine_t::Kh270);
+  encoders->init(Machine_t::Kh910);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
   // Not in front of Right Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
@@ -98,7 +93,7 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
   // Process rising edge
   encoders->encA_interrupt();
 
-  uint8_t startPosition = END_OFFSET[static_cast<int8_t>(encoders->getMachineType())];
+  uint8_t startPosition = END_LEFT_PLUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())];
 
   ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
@@ -117,68 +112,79 @@ TEST_F(EncodersTest, test_encA_rising_in_front_notKH270) {
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_KH270) {
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(MID_SENSOR_VALUE))
-      .RetiresOnSaturation();
   encoders->init(Machine_t::Kh270);
-
-  ASSERT_TRUE(encoders->getMachineType() == Machine_t::Kh270);
-  // We should not enter the falling function
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
-  // Create a rising edge
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
-  // We have not entered the rising function yet
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L)).Times(0);
-
-  encoders->encA_interrupt();
-
-  // Create a rising edge
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
-  // Enter rising function, direction is right
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
+  // Not in front of Right Hall Sensor
+  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
+      .WillRepeatedly(Return(MID_SENSOR_VALUE));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
-  // BeltShift is regular
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
+      .WillRepeatedly(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
+  // KH270 has no belt shift
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillRepeatedly(Return(HIGH));
+  // Create two rising edges (the initial state of A is assumed to be low)
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH));
+  // Always moving to the right: A == B
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH));
 
+  // Process rising edge
   encoders->encA_interrupt();
+
+  uint8_t startPosition = END_LEFT_PLUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())];
 
   ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
   ASSERT_EQ(encoders->getHallActive(), Direction_t::Left);
-  ASSERT_EQ(encoders->getPosition(), END_OFFSET[static_cast<int8_t>(encoders->getMachineType())]);
-  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
-  ASSERT_EQ(encoders->getBeltShift(), BeltShift::Shifted);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
+  ASSERT_EQ(encoders->getPosition(), startPosition);
+
+  // Process falling edge
+  encoders->encA_interrupt();
+
+  // Process rising edge
+  encoders->encA_interrupt();
+
+  // Should have moved and not reset position
+  ASSERT_EQ(encoders->getPosition(), 1 + startPosition);
 }
 
 TEST_F(EncodersTest, test_encA_rising_in_front_G_carriage) {
   // Create a rising edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
   // Enter rising function, direction is right
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true)).WillOnce(Return(false));
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
+      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
   // BeltShift is regular
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillOnce(Return(true));
 
   encoders->encA_interrupt();
 
-  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
 
   // Create a falling edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
+  // Enter falling function, direction is right
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(false));
+  // Not in front of Right Hall sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] - 1));
+
   encoders->encA_interrupt();
+
   // Create a rising edge
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
   // Enter rising function, direction is right
   EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(true));
   // In front of Left Hall Sensor
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
+      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
 
   encoders->encA_interrupt();
 
@@ -209,51 +215,100 @@ TEST_F(EncodersTest, test_encA_falling_not_in_front) {
 }
 
 TEST_F(EncodersTest, test_encA_falling_in_front) {
-  // Create a falling edge
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
-      .WillOnce(Return(HIGH))
-      .WillOnce(Return(HIGH));
-  // We have not entered the falling function yet
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R)).Times(0);
-
-  // Enter rising function, direction is left
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B)).WillOnce(Return(LOW)).WillOnce(Return(LOW));
-  // In front of Left Hall Sensor
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(FILTER_L_MIN[static_cast<int8_t>(encoders->getMachineType())]));
-  encoders->encA_interrupt();
-  encoders->encA_interrupt();
-
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(LOW));
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MAX[static_cast<int8_t>(encoders->getMachineType())] + 1));
-
-  encoders->encA_interrupt();
-
-  ASSERT_EQ(encoders->getDirection(), Direction_t::Right);
-  ASSERT_EQ(encoders->getHallActive(), Direction_t::Right);
-  ASSERT_EQ(encoders->getPosition(), 227);
+  encoders->init(Machine_t::Kh930);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
+  // Not in front of Left Hall Sensor
+  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+      .WillRepeatedly(Return(MID_SENSOR_VALUE));
+  // In front of Right Hall Sensor
+  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
+      .WillRepeatedly(Return(FILTER_R_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
+  // BeltShift is shifted
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillRepeatedly(Return(LOW));
+  // Create two falling edges (the initial state of A is assumed to be low)
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW));
+  // Always moving to the left: A != B
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH));
+
+  // Process rising edge
+  encoders->encA_interrupt();
+
+  // Process falling edge
+  encoders->encA_interrupt();
+
+  uint8_t startPosition = END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())];
+
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Left);
+  ASSERT_EQ(encoders->getHallActive(), Direction_t::Right);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::Lace);
+  ASSERT_EQ(encoders->getBeltShift(), BeltShift::Shifted);
+  ASSERT_EQ(encoders->getPosition(), startPosition);
+
+  // Process rising edge
+  encoders->encA_interrupt();
+
+  // Process falling edge
+  encoders->encA_interrupt();
+
+  // Should have moved and not reset position
+  ASSERT_EQ(encoders->getPosition(), startPosition - 1);
 }
 
-// requires FILTER_R_MIN != 0
-TEST_F(EncodersTest, test_encA_falling_set_K_carriage_KH910) {
-  ASSERT_TRUE(encoders->getMachineType() == Machine_t::Kh910);
-
-  // Create a rising edge
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(true));
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L));
-  encoders->encA_interrupt();
-
-  // falling edge
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A)).WillOnce(Return(false));
-  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B));
+TEST_F(EncodersTest, test_encA_falling_in_front_KH910) {
+  encoders->init(Machine_t::Kh910);
+  ASSERT_EQ(encoders->getCarriage(), Carriage_t::NoCarriage);
+  // Not in front of Left Hall Sensor
+  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
+      .WillRepeatedly(Return(MID_SENSOR_VALUE));
+  // K carriage in front of Right Hall Sensor: on a 910, the right sensor only
+  // triggers for the K carriage and with a low voltage
   EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_R))
-      .WillOnce(Return(FILTER_R_MIN[static_cast<int8_t>(encoders->getMachineType())] - 1));
+      .WillRepeatedly(Return(0));
+  // BeltShift is shifted
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_C)).WillRepeatedly(Return(LOW));
+  // Create two falling edges (the initial state of A is assumed to be low)
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_A))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW));
+  // Always moving to the left: A != B
+  EXPECT_CALL(*arduinoMock, digitalRead(ENC_PIN_B))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH))
+    .WillOnce(Return(LOW))
+    .WillOnce(Return(HIGH));
 
+  // Process rising edge
   encoders->encA_interrupt();
+
+  // Process falling edge
+  encoders->encA_interrupt();
+
+  uint8_t startPosition = END_RIGHT_MINUS_OFFSET[static_cast<int8_t>(encoders->getMachineType())];
+
+  ASSERT_EQ(encoders->getDirection(), Direction_t::Left);
+  ASSERT_EQ(encoders->getHallActive(), Direction_t::Right);
   ASSERT_EQ(encoders->getCarriage(), Carriage_t::Knit);
+  ASSERT_EQ(encoders->getBeltShift(), BeltShift::Shifted);
+  ASSERT_EQ(encoders->getPosition(), startPosition);
+
+  // Process rising edge
+  encoders->encA_interrupt();
+
+  // Process falling edge
+  encoders->encA_interrupt();
+
+  // Should have moved and not reset position
+  ASSERT_EQ(encoders->getPosition(), startPosition - 1);
 }
 
 TEST_F(EncodersTest, test_getPosition) {
@@ -284,15 +339,6 @@ TEST_F(EncodersTest, test_getCarriage) {
 TEST_F(EncodersTest, test_getMachineType) {
   Machine_t m = encoders->getMachineType();
   ASSERT_EQ(m, Machine_t::Kh910);
-}
-
-TEST_F(EncodersTest, test_init) {
-  EXPECT_CALL(*arduinoMock, analogRead(EOL_PIN_L))
-      .WillOnce(Return(MID_SENSOR_VALUE))
-      .RetiresOnSaturation();
-  encoders->init(Machine_t::Kh270);
-  Machine_t m = encoders->getMachineType();
-  ASSERT_EQ(m, Machine_t::Kh270);
 }
 
 TEST_F(EncodersTest, test_getHallValue) {


### PR DESCRIPTION
## Problem

Fixes carriages not being detected on the right on KH930-like machines and KH-270 (fixes #175, fixes #176, fixes #215, fixes #216).

## Proposed solution

On the KH910/KH950, we can't fix detecting Lace or Garter carriages on the right without an AYAB hardware change. But on other machines, the right sensor is just as functional as the left one.

So in this PR, we mostly copy the logic from `encA_rising` into `encA_falling`, and add a special case for the KH910 with its inverted K-only reading.

We also have to change the initialization logic (in `knitter.cpp`) slightly: the "carriage passed the turn mark" test does not work for the Garter carriage, because the position we track is actually that of its rightmost magnet pair. It turns out we can declare the machine ready as soon as a Garter carriage has been detected, since that means the carriage type cannot change further.

This PR also includes a fix for #215 — that was not really related to starting from the right, it was caused by a mishandled integer underflow in `calculatePixelAndSolenoid`. I chose to include the fix here, because it was small and also can avoid confusion while testing on the KH270.

## How to test

A firmware built from this PR can we flashed at this URL: https://code.jonathanperret.net/ayab-webtool/#pr=205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced carriage detection based on sensor measurements for improved operation.
	- Added refined state tracking to better determine the active carriage.

- **Refactor**
	- Streamlined detection logic and state transitions, ensuring more consistent performance.
	- Updated calibration parameters for sensor readings across different machine types.

- **Tests**
	- Revised test cases to align with the updated carriage detection and sensor calibration logic.

- **Bug Fixes**
	- Resolved issues with carriage detection under low voltage conditions for specific machine models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->