### PR TITLE
AyabAsync v1.1.1

### DIFF
--- a/.github/workflows/archive_build.yml
+++ b/.github/workflows/archive_build.yml
@@ -4,17 +4,10 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo and submodules
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Build Firmware
-        uses: ./.github/actions/build
-        with:
-          BUILD_WRAPPER_OUT_DIR: build_wrapper_out_dir
+      - name: Fetch binary
+        run: wget https://github.com/jpcornil-git/ayabAsync-firmware/releases/download/v1.1.0/firmware_uno_1_1_0.hex
       - name: Archive build
         uses: actions/upload-artifact@v3
         with:
           name: ${{format('{0}-{1}',github.sha,github.run_number)}}
-          path: build/*.hex
+          path: ./*.hex

--- a/.github/workflows/archive_build.yml
+++ b/.github/workflows/archive_build.yml
@@ -1,11 +1,27 @@
 name: Archive Build
 on: [push, pull_request]
+env:
+  AYAB_VERSION: v1.1.0
 jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch binary
-        run: wget https://github.com/jpcornil-git/ayabAsync-firmware/releases/download/v1.1.0/firmware_uno_1_1_0.hex
+        env:
+          firmwareUrl : https://github.com/jpcornil-git/ayabAsync-firmware/releases/download/${{ env.AYAB_VERSION }}/firmware_uno_1_1_0.hex
+        run: |
+          set -e
+          if ! wget --spider ${firmwareUrl}; then
+            echo "Error: Firmware file not found"
+            exit 1
+          fi
+          wget ${firmwareUrl}
+      - name: Verify hex file presence
+        run: |
+          if [ ! -f ./*.hex ]; then
+            echo "Error: No hex file found"
+            exit 1
+          fi
       - name: Archive build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/archive_build.yml
+++ b/.github/workflows/archive_build.yml
@@ -1,14 +1,14 @@
 name: Archive Build
 on: [push, pull_request]
 env:
-  AYAB_VERSION: v1.1.0
+  AYAB_VERSION: v1.1.1
 jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch binary
         env:
-          firmwareUrl : https://github.com/jpcornil-git/ayabAsync-firmware/releases/download/${{ env.AYAB_VERSION }}/firmware_uno_1_1_0.hex
+          firmwareUrl : https://github.com/jpcornil-git/ayabAsync-firmware/releases/download/${{ env.AYAB_VERSION }}/firmware_uno_1_1_1.hex
         run: |
           set -e
           if ! wget --spider ${firmwareUrl}; then


### PR DESCRIPTION
Add [AyabAsync](https://github.com/jpcornil-git/ayabAsync-firmware/tree/v1.1.1) v1.1.1 uno firmware to [webtool](https://code.jonathanperret.net/ayab-webtool/) to ease testing by others

More information about firmware changes/features is available here:
https://github.com/jpcornil-git/ayabAsync-firmware/releases/tag/v1.1.1

Firmware binaries for atmega2560 and uno R4 are also available from the link above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an environment variable for versioning, enhancing build management.
	- Added a new step to fetch firmware binaries, improving the download process.

- **Bug Fixes**
	- Implemented error handling for missing firmware files and verification for `.hex` files, ensuring better reliability during the build process.

- **Chores**
	- Updated the archiving process to include relevant build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->