### PR TITLE
Get the correct value for the lastLineFlag from cnfLine

### DIFF
--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -297,7 +297,10 @@ void Com::h_cnfLine(const uint8_t *buffer, size_t size) {
 
   if (GlobalKnitter::setNextLine(lineNumber)) {
     // Line was accepted
-    bool flagLastLine = bitRead(flags, 0U);
+
+    // A Python bool is represented as a byte 
+    // so read the second bit to get the value
+    bool flagLastLine = bitRead(flags, 1U);
     if (flagLastLine) {
       GlobalKnitter::setLastLine();
     }

--- a/test/test_com.cpp
+++ b/test/test_com.cpp
@@ -276,7 +276,7 @@ TEST_F(ComTest, test_cnfline_kh910) {
   uint8_t buffer[30] = {static_cast<uint8_t>(AYAB_API::cnfLine) /* 0x42 */,
                         0,
                         0,
-                        1,
+                        0x01,
                         0xDE,
                         0xAD,
                         0xBE,


### PR DESCRIPTION
https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/662

Python bools are bytes not bits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the handling of the `cnfLine` command to correctly determine the last line flag.
	- Improved reliability in serial communication by adjusting the flag reading mechanism.

- **Chores**
	- Added comments for potential future error handling improvements related to CRC-8 checks and message length assertions.
	- Made stylistic changes in the test cases for better clarity without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->