### PR TITLE
Encoders: only look at leftmost edge of left sensor signal

### DIFF
--- a/src/ayab/encoders.h
+++ b/src/ayab/encoders.h
@@ -180,6 +180,7 @@ private:
 
   volatile BeltShift_t m_beltShift;
   volatile Carriage_t m_carriage;
+  volatile Carriage_t m_previousDetectedCarriageLeft;
   volatile Direction_t m_direction;
   volatile Direction_t m_hallActive;
   volatile uint8_t m_position;
@@ -187,6 +188,7 @@ private:
   volatile bool m_passedLeft;
   volatile bool m_passedRight;
 
+  Carriage_t detectCarriageLeft();
   void encA_rising();
   void encA_falling();
 };


### PR DESCRIPTION
## Problem

Hopefully fixes #40.

## Theory of the issue

My current theory for why needles are sometimes wrongly selected (going to position `D` instead of `B`) is that the associated solenoid is activated too late in the process, causing the solenoid's armature to no longer be in contact with the solenoid core anymore by the time it gets powered, resulting in the selection lever not being prevented from moving the selector plate and selecting the needle to `D`.

In principle, this could be solved by simply increasing the "timing advance" (`START_OFFSET` in `ayab-firmware`) for activating solenoids when the carriage moves, i.e. instead of selecting for needle `0` when the carriage center is at needle `4` as we do currently, we could select for needle `0` as soon as the carriage center is over needle `3` (or even earlier).

But in the particular case of the lace carriage, this would interfere with the initial carriage detection. Because of the existence of the garter carriage, when we detect a lace carriage's magnet at the left Hall sensor, we wait for a few more needles before declaring to the desktop app that a lace carriage is present and requesting the first line's data. If an opposite polarity magnet is detected in that interval, we instead report a garter carriage. Also, once we have determined the carriage type and requested the line data, even though it normally arrives with milliseconds of the request, the firmware currently needs to wait for the next needle before effectively applying the data to the solenoids.

This adds up to a situation where we can't start selecting solenoids from the pattern until the lace carriage's center is over needle **4** (L97). If we are using a pattern that goes up to needle **0** (L100), the solenoid for that needle will be activated right after we receive the line data. But if we changed the timing advance to select for needle `0` when the carriage is over needle `3` instead, then that needle would never get selected properly, since by the time we have the pattern data we have already reached needle `4`.

A round of testing by @Adrienne200 with a machine affected by #40 showed however that the alternative firmware https://github.com/jpcornil-git/ayabAsync-firmware was not exhibiting the issue.

After comparing the code of the two firmwares, and measuring their timing behavior, it appeared that they were both using the same timing advance (selecting for needle `0` when the center is over needle `4`). So, something else had to be different.

Looking into the left Hall sensor logic as suggested by @jpcornil-git proved promising: it turns out `ayabAsync-firmware` does something different than `ayab-firmware` there. Where `ayab-firmware` currently resets the carriage position to zero as long as a magnet is detected in front of the sensor (effectively declaring that needle `0` is at the rightmost position where the magnet can be detected), `ayabAsync-firmware` instead places needle `0` at the position where the sensor signal reaches an extremum (minimum for the lace carriage).

Since we have observed that the area where the sensor was triggered by a magnet could reach up to three needles in width, this could create a difference of one to two needles in the timing of solenoid activation between the firmwares. This could be enough to make the difference between issue #40 manifesting or not.

## Proposed solution

In this PR, we change the logic for the left Hall sensor to reset the carriage position to "zero" (actually `END_LEFT_PLUS_OFFSET` but that corresponds to needle `0`) only when the sensor signal is seen going from a mid-level value to a "magnet present" value, while the carriage is moving left. In effect this sets the "zero" position at the leftmost edge of the magnet detection area. This should shift everything left by one or two needles, leaving more time for the solenoids to be activated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for detecting the left carriage type.
	- Added a new member variable to enhance tracking of the left carriage state.

- **Bug Fixes**
	- Improved test cases for the encoder's rising edge detection, ensuring accurate sensor reading expectations.

- **Tests**
	- Enhanced clarity and maintainability of the testing framework with the introduction of constants for sensor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->