### PR TITLE
Allow 1.0.0 tag to trigger a release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,7 +2,9 @@ name: Create Release
 on:
   push:
     tags:
-    - 'v?[0-9]+.[0-9]+.[0-9]+-?[a-zA-Z0-9]*'
+      # Not a regex! See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

Creating a `1.0.0` tag does not trigger the creation of a release.

## Cause and proposed solution

There's a subtle error in the tag filter of the `create-release.yml` GitHub Actions workflow.

It ends with `[a-zA-Z0-9]*` to allow a possibly empty release name suffix such as `beta5`. But while this is valid regex syntax, it has a different meaning in the [GitHub Actions filter syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet): there, `[a-zA-Z0-9]` is taken to match one character from the given set, then `*` allows zero or more of any character that is not `/`.

The result is that an empty suffix is not allowed.

The proposed fix in this PR splits the pattern in two variants, one without a suffix and one that has a required suffix.

I tested on my fork that this is sufficient to let non-suffixed tags trigger release creation.