### PR TITLE
Use the fixed shield wiring for the 910 right-side sensor

### DIFF
--- a/src/ayab/board.h
+++ b/src/ayab/board.h
@@ -29,6 +29,8 @@
 // Pin Assignments
 constexpr uint8_t EOL_PIN_R = A0; // Analog
 constexpr uint8_t EOL_PIN_L = A1; // Analog
+constexpr uint8_t EOL_PIN_R_L = 7;
+constexpr uint8_t EOL_PIN_R_DETECT = 8;
 
 constexpr uint8_t ENC_PIN_A = 2;
 constexpr uint8_t ENC_PIN_B = 3;

--- a/src/ayab/tester.h
+++ b/src/ayab/tester.h
@@ -117,6 +117,7 @@ private:
   void autoTestOdd() const;
   void handleTimerEvent();
 
+  Machine_t m_machineType = Machine_t::NoMachine;
   bool m_autoReadOn = false;
   bool m_autoTestOn = false;
   unsigned long m_lastTime = 0U;


### PR DESCRIPTION
# Problem

The current AYAB hardware has an issue on 910/950 machines where the signal for the lace carriage from the right-side position sensor is shorted to ground.

# Proposed solution

This PR modifies the firmware to handle AYAB hardware (shield or Interface) fixed to route the affected signal to pin D7 of the Arduino. To distinguish fixed hardware, pins D7 and D8 have to be shorted as well.