### PR TITLE
Upgrade deprecated SonarQube action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,8 +17,8 @@ runs:
     - run: |
         pip install --upgrade platformio
       shell: bash
-    # Install sonar-scanner and build-wrapper
-    - uses: SonarSource/sonarcloud-github-c-cpp@v3
+    # Install Sonar build wrapper
+    - uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5
     # Build for Arduino UNO
     - run: |
         build-wrapper-linux-x86-64 --out-dir ${{ inputs.BUILD_WRAPPER_OUT_DIR }} platformio run --environment uno

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,8 @@ jobs:
   run-test:
     runs-on: ubuntu-latest
     if: ${{!github.event.pull_request.draft}}
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Checkout repo and submodules
         uses: actions/checkout@v4
@@ -41,9 +43,8 @@ jobs:
           files: |
             ./test/build/xml_out/*
       - name: Analyze with SonarCloud
-        if: github.repository == 'AllYarnsAreBeautiful/ayab-firmware' && ( ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'AllYarnsAreBeautiful/ayab-firmware' ) || github.event_name == 'push' )
+        if: ${{ env.SONAR_TOKEN != '' }}
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_WRAPPER_OUT_DIR: build_wrapper_out_dir
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           files: |
             ./test/build/xml_out/*
-      - name: Analyze with SonarCloud
+      - name: Analyze with SonarQube
         if: ${{ env.SONAR_TOKEN != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BUILD_WRAPPER_OUT_DIR: build_wrapper_out_dir
-        run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" --define sonar.coverageReportPaths="./test/build/coverage.xml"
+        uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands=build_wrapper_out_dir/compile_commands.json
+            --define sonar.coverageReportPaths="./test/build/coverage.xml"


### PR DESCRIPTION
## Problem

The current GitHub Action used to run the SonarQube analysis (https://github.com/SonarSource/sonarcloud-github-c-cpp) is deprecated and logs a warning.

Also, the action is currently failing to upload analysis results to the SonarQube cloud, which breaks builds on `main` (see https://github.com/AllYarnsAreBeautiful/ayab-firmware/actions/runs/16329342678).

## Proposed solution

As recommended in https://github.com/SonarSource/sonarcloud-github-c-cpp/blob/main/README.md, replace that action with https://github.com/SonarSource/sonarqube-scan-action.

This change removes the warning but unfortunately does not fix the upload issue. It seems the `SONAR_TOKEN` has become invalid. @dl1com could you look into it please? I tested creating a SonarQube cloud project for my fork and configuring the analysis to upload there and everything worked fine so I don't think it's a generalized SonarQube issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the latest official SonarQube scanning actions.
  * Simplified SonarQube analysis step with improved configuration and token-based triggering.
  * No changes to end-user features or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->