### PR TITLE
Add support for KH910 RHS sensor HW fix

### DIFF
--- a/lib/components/hallsensor/hallsensor.cpp
+++ b/lib/components/hallsensor/hallsensor.cpp
@@ -13,9 +13,8 @@ HallSensor::HallSensor(hardwareAbstraction::HalInterface *hal, uint8_t sensorPin
 
   _config = nullptr;
 
-  // Default pin mode (analog/digital for pin1/2 respectively)
+  // Default pin mode for sensorPin1 (analog)
   _hal->pinMode(_sensorPin1, INPUT);
-  _hal->pinMode(_sensorPin2, INPUT_PULLUP);
 
   // HW fix rewires EOL_R_L signal (previously grounded) to sensorPin2 and detectPin.
   // Firmware uses detectPin to check presence of the fix during the initialiation phase:
@@ -25,11 +24,14 @@ HallSensor::HallSensor(hardwareAbstraction::HalInterface *hal, uint8_t sensorPin
   // -> without the fix sensorPin2 is not connected and is pulled HIGH and _isPin2Wired is set to false
   // After detection detectPin is configured as INPUT to avoid loading or driving the EOL_R_L signal.
   if((sensorPin2 != PIN_NONE) && (detectPin != PIN_NONE)) {
+    _hal->pinMode(_sensorPin2, INPUT_PULLUP);
     _hal->digitalWrite(detectPin, LOW);
     _hal->pinMode(detectPin, OUTPUT);
     _hal->delayMicroseconds(PULLUP_DELAY);
     _isPin2Wired = (_hal->digitalRead(_sensorPin2) == LOW);
+    // Restore both pins to input state (no pull-up)
     _hal->pinMode(detectPin, INPUT);
+    _hal->pinMode(_sensorPin2, INPUT);
   }
 
   _resetDetector();
@@ -42,6 +44,10 @@ void HallSensor::config(HallSensor::Config *config) {
   if(_config->flags & HALLSENSOR_DIGITAL) {
     // KH910 right sensor, digital mode for K input
     _hal->pinMode(_sensorPin1, INPUT_PULLUP);
+    if(_isPin2Wired) {
+      // L input also wired, use pull-up/digital mode
+      _hal->pinMode(_sensorPin2, INPUT_PULLUP);
+    }
   }
 }
 

--- a/lib/components/hallsensor/hallsensor.cpp
+++ b/lib/components/hallsensor/hallsensor.cpp
@@ -188,19 +188,23 @@ bool HallSensor::_detectCarriage() {
 }
 
 void HallSensor::_readSensor() {
-  if (_config->flags & HALLSENSOR_DIGITAL) {
-    int kValue = _hal->digitalRead(_sensorPin1);
-    int lValue = _hal->digitalRead(_sensorPin2);
-    // Mimic analogRead() for digital sensors
-    if (kValue == LOW) {
-      _sensorValue = 1023; // K magnet detected
-    } else if ((lValue == HIGH) && _isPin2Wired) {
-      _sensorValue = 0; // L magnet detected
-    } else {
-      _sensorValue = 512; // No magnet detected
-    }
+  if( _config == nullptr) {
+    _sensorValue = 512; // Mid-scale
   } else {
-    // Analog sensor, read voltage
-    _sensorValue = _hal->analogRead(_sensorPin1);
+    if (_config->flags & HALLSENSOR_DIGITAL) {
+      int kValue = _hal->digitalRead(_sensorPin1);
+      int lValue = _hal->digitalRead(_sensorPin2);
+      // Mimic analogRead() for digital sensors
+      if (kValue == LOW) {
+        _sensorValue = 1023; // K magnet detected
+      } else if ((lValue == HIGH) && _isPin2Wired) {
+        _sensorValue = 0; // L magnet detected
+      } else {
+        _sensorValue = 512; // No magnet detected
+      }
+    } else {
+      // Analog sensor, read voltage
+      _sensorValue = _hal->analogRead(_sensorPin1);
+    }
   }
 }

--- a/lib/components/hallsensor/hallsensor.h
+++ b/lib/components/hallsensor/hallsensor.h
@@ -5,9 +5,12 @@
 #include "encoder.h"
 #include "hal.h"
 
-#define HALLSENSOR_K_LOW  (1<<0)
-#define HALLSENSOR_L_HIGH (1<<1)
-#define HALLSENSOR_K270_K (1<<2)
+// No pin indication
+#define PIN_NONE 0xff
+
+// Hall sensor flags
+#define HALLSENSOR_DIGITAL (1<<0)
+#define HALLSENSOR_K270_K  (1<<1)
 
 class HallSensor {
  public:
@@ -19,7 +22,7 @@ class HallSensor {
     uint8_t flags;
   };
 
-  HallSensor(hardwareAbstraction::HalInterface *hal, uint8_t pin);
+  HallSensor(hardwareAbstraction::HalInterface *hal, uint8_t sensorPin1, uint8_t sensorPin2 = PIN_NONE, uint8_t detectPin = PIN_NONE);
   ~HallSensor() = default;
 
   // Config sensor's position and thresholds
@@ -58,14 +61,14 @@ class HallSensor {
 
   hardwareAbstraction::HalInterface *_hal;
 
-  uint8_t _pin;
+  uint8_t _sensorPin1, _sensorPin2;
 
   Config *_config;
 
   uint16_t _sensorValue;
   uint16_t _thresholdLow;
   uint16_t _thresholdHigh;
-  bool _isKasG;
+  bool _isPin2Wired; // KH910 HW fix for RHS sensor is present
 
   int16_t _detectedPosition;
   CarriageType _detectedCarriage;

--- a/lib/components/hallsensor/hallsensor.h
+++ b/lib/components/hallsensor/hallsensor.h
@@ -68,7 +68,10 @@ class HallSensor {
   uint16_t _sensorValue;
   uint16_t _thresholdLow;
   uint16_t _thresholdHigh;
-  bool _isPin2Wired; // KH910 HW fix for RHS sensor is present
+  /// Indicate if the second sensor pin is wired to a hall sensor
+  /// or not (used for KH910 right sensor which has two digital
+  /// outputs for K and L but L is not wired on all hardware versions)
+  bool _isPin2Wired;
 
   int16_t _detectedPosition;
   CarriageType _detectedCarriage;

--- a/lib/components/knitter/knitter.cpp
+++ b/lib/components/knitter/knitter.cpp
@@ -16,7 +16,7 @@ Knitter::Knitter(hardwareAbstraction::HalInterface *hal) : API(hal) {
   _hal->pinMode(ENC_PIN_C, INPUT);
 
   _hall_left = new HallSensor(_hal, EOL_L_PIN);
-  _hall_right = new HallSensor(_hal, EOL_R_PIN);
+  _hall_right = new HallSensor(_hal, EOL_R_PIN, EOL_R_L_PIN, EOL_R_DETECT_PIN);
 
   const uint8_t mcp23008_i2c_addresses[2] = {MCP23008_ADD0, MCP23008_ADD1};
   _solenoids = new Solenoids(_hal, mcp23008_i2c_addresses);

--- a/lib/components/machine/machine.cpp
+++ b/lib/components/machine/machine.cpp
@@ -46,10 +46,7 @@ HallSensor::Config *Machine::getSensorConfig(MachineSide side) {
   sensorConfig->flags = 0;
 
   if ((_type == MachineType::Kh910) && (side == MachineSide::Right)) {
-    // KH910 unmodified; incorrect shield implementation, only North pole as digital low
-    sensorConfig->thresholdLow = 100;
-    sensorConfig->thresholdHigh = 1024;
-    sensorConfig->flags |= HALLSENSOR_K_LOW;
+    sensorConfig->flags |= HALLSENSOR_DIGITAL;
   } else if (_type == MachineType::Kh270) {
     sensorConfig->flags |= HALLSENSOR_K270_K;
   }

--- a/lib/platform/arch/atmelavr/platform/platform.cpp
+++ b/lib/platform/arch/atmelavr/platform/platform.cpp
@@ -33,6 +33,10 @@ namespace hardwareAbstraction {
         return ::millis();
     }
 
+    void Platform::delayMicroseconds(unsigned int us) {
+        ::delayMicroseconds(us);
+    }
+
     void Platform::attachInterrupt(uint8_t interruptNum, void (*userFunc)(), int mode) {
         ::attachInterrupt(digitalPinToInterrupt(interruptNum), userFunc, mode);
     }

--- a/lib/platform/arch/atmelavr/platform/platform.h
+++ b/lib/platform/arch/atmelavr/platform/platform.h
@@ -18,6 +18,7 @@ class Platform : public HalInterface {
   void analogWrite(uint8_t pin, uint8_t value) override;
   int analogRead(uint8_t pin) override;
   unsigned long millis() override;
+  void delayMicroseconds(unsigned int us) override;
   void attachInterrupt(uint8_t interruptNum, void (*userFunc)(),
                        int mode) override;
 };

--- a/lib/platform/arch/renesas-ra/platform/platform.cpp
+++ b/lib/platform/arch/renesas-ra/platform/platform.cpp
@@ -33,6 +33,10 @@ namespace hardwareAbstraction {
         return ::millis();
     }
 
+    void Platform::delayMicroseconds(unsigned int us) {
+        ::delayMicroseconds(us);
+    }
+
     void Platform::attachInterrupt(uint8_t interruptNum, void (*userFunc)(), int mode) {
         // Interrupt modes appended to PinStatus and shifted by 1 compared to AVR
         ::attachInterrupt(digitalPinToInterrupt(interruptNum), userFunc, (::PinStatus) (mode+1));

--- a/lib/platform/arch/renesas-ra/platform/platform.h
+++ b/lib/platform/arch/renesas-ra/platform/platform.h
@@ -18,6 +18,7 @@ class Platform : public HalInterface {
   void analogWrite(uint8_t pin, uint8_t value) override;
   int analogRead(uint8_t pin) override;
   unsigned long millis() override;
+  void delayMicroseconds(unsigned int us) override;
   void attachInterrupt(uint8_t interruptNum, void (*userFunc)(),
                        int mode) override;
 };

--- a/lib/platform/common/hal/hal.h
+++ b/lib/platform/common/hal/hal.h
@@ -44,6 +44,7 @@ namespace hardwareAbstraction {
         virtual void analogWrite(uint8_t pin, uint8_t value) = 0;
         virtual int analogRead(uint8_t pin) = 0;
         virtual unsigned long millis() = 0;
+        virtual void delayMicroseconds(unsigned int us) = 0;
         virtual void attachInterrupt(uint8_t interruptNum, void (*userFunc)(), int mode) = 0;
 
         I2cInterface *i2c;

--- a/lib/platform/common/shield/shield.h
+++ b/lib/platform/common/shield/shield.h
@@ -14,6 +14,10 @@
 #define EOL_R_PIN 0  // Right
 #define EOL_L_PIN 1  // Left
 
+// Hall detectors (digital, KH910 RHS)
+#define EOL_R_L_PIN 7
+#define EOL_R_DETECT_PIN 8
+
 // MCP23008
 #define MCP23008_ADD0 0x20
 #define MCP23008_ADD1 0x21


### PR DESCRIPTION
The hardware fix rewires the `EOL_R_L` signal (previously grounded) to pins 7 and 8.
The firmware uses pin 8 to detect the presence of the fix during the initialization phase:

- Pin 7 is configured as an input with a pull-up resistor.
- Pin 8 is configured as an output and goes LOW (safe because EOL_R_L only goes LOW).

-> With the fix, pin 7 follows pin 8 and goes LOW (`_isPin2Wired` = true).
-> Without the fix, pin 7 is unconnected and goes HIGH (`_isPin2Wired` = false).

After detection, pin 8 is configured as an INPUT.

When the machine is set to KH910, the RHS sensor is now configured as `HALLSENSOR_DIGITAL`.
For `HALLSENSOR_DIGITAL` sensors, EOL_R_K is still supported to maintain the same behavior as before for older shields (without the fix), while EOL_R_L is only supported if `_isPin2Wired` is true.

In addition, digital sensor outputs are now converted to virtual analog values ​​to mimic those of analog sensors and simplify the detection process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for dual‑pin digital Hall sensors with automatic wiring detection for improved compatibility and stability.
  - Improved timing precision with microsecond delays on supported platforms.
- Bug Fixes
  - More reliable carriage/end‑of‑line detection on KH910 (right side), using default thresholds for better accuracy.
  - More consistent sensor readings in both digital and analog modes.
- Chores
  - Updated hardware pin mappings for KH910 right‑side Hall sensor to simplify setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->