### PR TITLE
Fix the hall sensor pin definitions

### DIFF
--- a/lib/components/knitter/knitter.cpp
+++ b/lib/components/knitter/knitter.cpp
@@ -17,12 +17,12 @@ Knitter::Knitter(hardwareAbstraction::HalInterface *hal) : API(hal) {
   _encoder = new Encoder(_hal, Shield::Encoder::ENC_A_PIN, Shield::Encoder::ENC_B_PIN);
   _hal->pinMode(Shield::Encoder::ENC_C_PIN, INPUT);
 
-  _hall_left = new HallSensor(_hal, Shield::HallDetectors::Analog::EOL_L_PIN);
+  _hall_left = new HallSensor(_hal, Shield::HallDetectors::EOL_L_PIN);
   _hall_right = new HallSensor(
                   _hal,
-                  Shield::HallDetectors::Analog::EOL_R_PIN,
-                  Shield::HallDetectors::Digital::EOL_R_L_PIN,
-                  Shield::HallDetectors::Digital::EOL_R_DETECT_PIN
+                  Shield::HallDetectors::EOL_R_PIN,
+                  Shield::HallDetectors::EOL_R_L_PIN,
+                  Shield::HallDetectors::EOL_R_DETECT_PIN
                 );
 
   GpioExpander* gpio_expander[2];

--- a/lib/platform/common/shield/shield.h
+++ b/lib/platform/common/shield/shield.h
@@ -25,16 +25,15 @@ namespace Shield {
 
     // Hall detectors
     struct HallDetectors {
-        // Analog
-        struct Analog {
-            static constexpr uint8_t EOL_R_PIN = 0;  // Right
-            static constexpr uint8_t EOL_L_PIN = 1;  // Left
-        };
-        // Digital (KH910 RHS)
-        struct Digital {
-            static constexpr uint8_t EOL_R_L_PIN = 7;
-            static constexpr uint8_t EOL_R_DETECT_PIN = 8;
-        };
+        #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
+            static constexpr uint8_t EOL_R_PIN = 14; // AN0/D14: Right (K digital input for KH910)
+            static constexpr uint8_t EOL_L_PIN = 15; // AN1/D15: Left
+        #elif defined(ARDUINO_AVR_MEGA2560)
+            static constexpr uint8_t EOL_R_PIN = 54; // AN0/D54: Right (K digital input for KH910)
+            static constexpr uint8_t EOL_L_PIN = 55; // AN1/D55: Left
+        #endif
+        static constexpr uint8_t EOL_R_L_PIN = 7; // Right L digital input for KH910
+        static constexpr uint8_t EOL_R_DETECT_PIN = 8; // Shorted to EOL_R_L_PIN to detect HW fix
     };
 
     // GPIO expanders


### PR DESCRIPTION
Analog inputs were previously defined as analog channels (analogRead accepts both analog channel and pin numbering) but now that EOL_R_PIN is also used as a digital input for the KH910, it MUST be defined as a digital.