### PR TITLE
Add dummy GPIO expanders when none are detected

### DIFF
--- a/lib/api/api.h
+++ b/lib/api/api.h
@@ -60,9 +60,14 @@ enum class AYAB_API : uint8_t {
   indicateState = 0x84,
 
   debugBase = 0xf0,
+  debugPrint = 0xf1,
   debugRequestPeek = 0xf8,
   debugConfirmPeek = 0xf9,
   debugRequestPoke = 0xfa
+};
+
+enum class debugPrintMessageType : uint8_t {
+  i2cWrite = 0x00
 };
 
 class API {

--- a/lib/components/knitter/knitter.cpp
+++ b/lib/components/knitter/knitter.cpp
@@ -128,12 +128,18 @@ void Knitter::schedule() {
 
 void Knitter::_detectGpioExpanders(hardwareAbstraction::HalInterface *hal, const uint8_t i2cAddress[][2], GpioExpander* gpio_expander[2]) {
   // FIXME: First one is selected when none are detected -> should raise an error towards desktop app instead
-  int i2c_address_set = 0;
+  int i2c_address_set = -1;
   for (int id = 0; (i2cAddress[id][0] != 0) || (i2cAddress[id][1] != 0); id++) {
     if (hal->i2c->detect(i2cAddress[id][0]) && hal->i2c->detect(i2cAddress[id][1])) {
       i2c_address_set = id;
       break;
     };
+  }
+
+  if (i2c_address_set == -1) {
+    gpio_expander[0] = new DummyExpander(hal, 0);
+    gpio_expander[1] = new DummyExpander(hal, 1);
+    return;
   }
 
   for (int i = 0; i < 2; i++) {

--- a/lib/devices/gpio_expander/gpio_expander.cpp
+++ b/lib/devices/gpio_expander/gpio_expander.cpp
@@ -1,7 +1,16 @@
 #include "gpio_expander.h"
+#include "api.h"
+#include "crc8.h"
 
 GpioExpander::GpioExpander(hardwareAbstraction::HalInterface *hal, const uint8_t i2cAddress) {
   _hal = hal;
   _i2cAddress = i2cAddress;
   _cache_invalid = true;
+}
+
+void DummyExpander::update(uint8_t value) {
+  uint8_t message[] = {(uint8_t)AYAB_API::debugPrint, (uint8_t)debugPrintMessageType::i2cWrite, (uint8_t)_i2cAddress, (uint8_t)value, 0};
+  size_t size = sizeof(message);
+  message[size - 1] = crc8(message, size - 1);
+  _hal->packetSerial->send(message, size);
 }

--- a/lib/devices/gpio_expander/gpio_expander.h
+++ b/lib/devices/gpio_expander/gpio_expander.h
@@ -17,4 +17,15 @@ class GpioExpander {
   bool _cache_invalid;
 };
 
+class DummyExpander final : public GpioExpander {
+ public:
+
+  DummyExpander(hardwareAbstraction::HalInterface *hal, uint8_t i2cAddress)
+      : GpioExpander(hal, i2cAddress) {};
+  ~DummyExpander() = default;
+
+  // Update output latch register
+  void update(uint8_t value) override;
+};
+
 #endif


### PR DESCRIPTION
This avoid crash when a shield is not present and therefore run tests on MCU without shields (GPIO updates are transmitted using a debugPrint message iback to the application)