### PR TITLE
Quick and dirty I2C color changer support

### DIFF
--- a/src/ayab/board.h
+++ b/src/ayab/board.h
@@ -42,6 +42,8 @@ constexpr uint8_t LED_PIN_B = 6; // yellow LED
 
 constexpr uint8_t PIEZO_PIN = 9;
 
+constexpr uint8_t COLOR_CHANGER_I2C_ADDRESS = 0x22;
+
 #ifdef DBG_NOMACHINE               // Turn on to use DBG_BTN_PIN as EOL Trigger
 constexpr uint8_t DBG_BTN_PIN = 7; // DEBUG BUTTON
 #endif

--- a/src/ayab/com.cpp
+++ b/src/ayab/com.cpp
@@ -279,7 +279,7 @@ void Com::h_cnfLine(const uint8_t *buffer, size_t size) {
   }
 
   uint8_t lineNumber = buffer[1];
-  /* uint8_t color = buffer[2];  */ // currently unused
+  uint8_t color = buffer[2];
   uint8_t flags = buffer[3];
 
   for (uint8_t i = 0U; i < lenLineBuffer; i++) {
@@ -296,6 +296,10 @@ void Com::h_cnfLine(const uint8_t *buffer, size_t size) {
   }
 
   if (GlobalKnitter::setNextLine(lineNumber)) {
+    Wire.beginTransmission(COLOR_CHANGER_I2C_ADDRESS);
+    Wire.write(1 << color);
+    Wire.endTransmission();
+
     // Line was accepted
     bool flagLastLine = bitRead(flags, 0U);
     if (flagLastLine) {


### PR DESCRIPTION
## Purpose

This is a quick proof of concept of driving a color changer through an I2C I/O expander.

The eventual plan is to integrate a cleaner implementation into the `ayabAsync` codebase.
